### PR TITLE
Move singing parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,6 @@ lint/tmp/
 
 # Android Profiling
 *.hprof
+
+android/key.propierties
+*.so

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,11 +11,20 @@ plugins {
     id("org.spdx.sbom") version "0.7.0"
 }
 
+def keystoreProperties = new Properties()
+def keystorePropertiesFile = rootProject.file('android/key.properties')
+if (keystorePropertiesFile.exists()) {
+    keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+}
+
+
 android {
     signingConfigs {
         debug {
-            storeFile file('OpenMobileNetworkToolkit-key.jks')
-            keyAlias 'key0'
+            keyAlias keystoreProperties['keyAlias']
+            keyPassword keystoreProperties['keyPassword']
+            storeFile keystoreProperties['storeFile'] ? file(keystoreProperties['storeFile']) : null
+            storePassword keystoreProperties['storePassword']
         }
     }
     compileSdk 34

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Iperf3/Iperf3LibLoader.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Iperf3/Iperf3LibLoader.java
@@ -23,7 +23,8 @@ public class Iperf3LibLoader {
         "iperf3.11",
         "iperf3.12",
         "iperf3.15",
-        "iperf3.16"
+        "iperf3.16",
+        "iperf3.17.1"
     );
 
     protected static synchronized void load() {


### PR DESCRIPTION
Moves local signing parameter to `[project]/android/key.properties`

create file with following parameter: 
```
storePassword=<password-from-previous-step>
keyPassword=<password-from-previous-step>
keyAlias=upload
storeFile=<keystore-file-location>
```


[More](https://docs.flutter.dev/deployment/android#signing-the-app)