### PR TITLE
Fix Crash getMEID()

### DIFF
--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/DataProvider/DataProvider.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/DataProvider/DataProvider.java
@@ -103,6 +103,7 @@ public class DataProvider extends TelephonyCallback implements LocationListener,
     private ArrayList<CellInformation> ssi = new ArrayList<>();
     private WifiInformation wi = null;
     private LocationManager lm;
+    private PackageManager pm;
     private final BuildInformation buildInformation = new BuildInformation();
     // Time stamp, should be updated on each update of internal data caches
     private long ts = System.currentTimeMillis();
@@ -113,7 +114,7 @@ public class DataProvider extends TelephonyCallback implements LocationListener,
         ct = context;
         spg = SharedPreferencesGrouper.getInstance(ct);
         permission_phone_state = gv.isPermission_phone_state();
-
+        pm = ct.getPackageManager();
         // we can only relay on some APIs if this is a phone.
         if (gv.isFeature_telephony()) {
             cm = (ConnectivityManager) ct.getSystemService(Context.CONNECTIVITY_SERVICE);
@@ -243,7 +244,7 @@ public class DataProvider extends TelephonyCallback implements LocationListener,
         if (tm.hasCarrierPrivileges()) {
             try {
                 di.setIMEI(tm.getImei());
-                di.setMEID(tm.getMeid());
+                if (pm.hasSystemFeature(PackageManager.FEATURE_TELEPHONY_CDMA)) di.setMEID(tm.getMeid());
                 di.setSimSerial(tm.getSimSerialNumber());
                 di.setSubscriberId(tm.getSubscriberId());
                 di.setNetworkAccessIdentifier(tm.getNai());


### PR DESCRIPTION
This PR provides a minor fix for cases where `getMEID()` is called without verifying the `FEATURE_TELEPHONY_CDMA` permission.
The issue was observed on the S25 running Android 15.