### PR TITLE
Configure OMNT via Intent

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -146,6 +146,19 @@
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
             </intent-filter>
         </receiver>
+        <receiver android:name="de.fraunhofer.fokus.OpenMobileNetworkToolkit.Receiver.JsonConfigReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="de.fraunhofer.fokus.OpenMobileNetworkToolkit.CONFIG_JSON" />
+            </intent-filter>
+        </receiver>
+
+        <receiver android:name="de.fraunhofer.fokus.OpenMobileNetworkToolkit.Receiver.FileConfigReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="de.fraunhofer.fokus.OpenMobileNetworkToolkit.CONFIG_FILE" />
+            </intent-filter>
+        </receiver>
 
         <activity
             android:name="de.fraunhofer.fokus.OpenMobileNetworkToolkit.MainActivity"

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Receiver/FileConfigReceiver.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Receiver/FileConfigReceiver.java
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText:  2025 Peter Hasse <peter.hasse@fokus.fraunhofer.de>
+ * SPDX-FileCopyrightText: 2025 Johann Hackler <johann.hackler@fokus.fraunhofer.de>
+ * SPDX-FileCopyrightText: 2025 Fraunhofer FOKUS
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause-Clear
+ */
+
+package de.fraunhofer.fokus.OpenMobileNetworkToolkit.Receiver;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.util.Log;
+
+import de.fraunhofer.fokus.OpenMobileNetworkToolkit.Preferences.SharedPreferencesIO;
+
+public class FileConfigReceiver extends BroadcastReceiver {
+    private static final String TAG = "FileConfigReceiver";
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        String filePath = intent.getStringExtra("filePath");
+        Log.e(TAG, "onReceive: got following path"+ filePath);
+        if (filePath == null) {
+            Log.e(TAG, "onReceive: filePath is null");
+            return;
+        }
+        try {
+            String jsonString = new String(java.nio.file.Files.readAllBytes(java.nio.file.Paths.get(filePath)));
+            if (jsonString.isEmpty()) {
+                Log.e(TAG, "onReceive: JSON string is empty");
+                return;
+            }
+            Log.i(TAG, "onReceive: Successfully read JSON from file: " + filePath);
+            SharedPreferencesIO.importPreferences(context, jsonString);
+        } catch (java.io.IOException e) {
+            Log.e(TAG, "Failed to read JSON from file: " + filePath, e);
+        }
+
+    }
+}

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Receiver/JsonConfigReceiver.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Receiver/JsonConfigReceiver.java
@@ -1,0 +1,30 @@
+/*
+ * SPDX-FileCopyrightText:  2025 Peter Hasse <peter.hasse@fokus.fraunhofer.de>
+ * SPDX-FileCopyrightText: 2025 Johann Hackler <johann.hackler@fokus.fraunhofer.de>
+ * SPDX-FileCopyrightText: 2025 Fraunhofer FOKUS
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause-Clear
+ */
+
+package de.fraunhofer.fokus.OpenMobileNetworkToolkit.Receiver;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.util.Log;
+
+import de.fraunhofer.fokus.OpenMobileNetworkToolkit.Preferences.SharedPreferencesIO;
+
+public class JsonConfigReceiver extends BroadcastReceiver {
+    private final String TAG = "JsonConfigReceiver";
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        String jsonString = intent.getStringExtra("jsonData");
+        Log.e(TAG, "onReceive: got jsonString:"+jsonString );
+        if (jsonString == null) {
+            return;
+        }
+        SharedPreferencesIO.importPreferences(context, jsonString);
+   }
+}

--- a/docs/config.md
+++ b/docs/config.md
@@ -125,3 +125,25 @@ An example of a config file is shown below:
     }
 }
 ```
+
+## Config File via Intent
+
+You can also pass the config file via an Intent to the App.
+Either via JSON directly or as a path to the config file.
+
+
+### Config via JSON
+```bash
+adb shell am broadcast \
+  -a de.fraunhofer.fokus.OpenMobileNetworkToolkit.CONFIG_JSON \
+  -n de.fraunhofer.fokus.OpenMobileNetworkToolkit/.Receiver.JsonConfigReceiver \
+  -e jsonData '{}'
+```
+
+### Config via File Path
+```bash
+adb shell am broadcast \
+  -a de.fraunhofer.fokus.OpenMobileNetworkToolkit.CONFIG_FILE \
+  -n de.fraunhofer.fokus.OpenMobileNetworkToolkit/.Receiver.FileConfigReceiver
+  -e filePath 'PATH_TO_YOUR_CONFIG_FILE' 
+```


### PR DESCRIPTION
## Added
- add support to configure OMNT via Intent

#### Config via JSON
```bash
adb shell am broadcast \
  -a de.fraunhofer.fokus.OpenMobileNetworkToolkit.CONFIG_JSON \
  -n de.fraunhofer.fokus.OpenMobileNetworkToolkit/.Receiver.JsonConfigReceiver \
  -e jsonData '{}'
```

#### Config via File Path
```bash
adb shell am broadcast \
  -a de.fraunhofer.fokus.OpenMobileNetworkToolkit.CONFIG_FILE \
  -n de.fraunhofer.fokus.OpenMobileNetworkToolkit/.Receiver.FileConfigReceiver
  -e filePath 'PATH_TO_YOUR_CONFIG_FILE' 
```