### PR TITLE
Refactor Config Import/Export

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: apache2
  */
 
+
 import groovy.xml.Namespace
 
 plugins {
@@ -177,6 +178,7 @@ tasks.register('generatePrefsDoc') {
     def stringsFile = file("$projectDir/src/main/res/values/strings.xml")
     def arraysFile = file("$projectDir/src/main/res/values/arrays.xml")
     def outputFile = file("$projectDir/../docs/preferences.md")
+    def jsonOutputFile = file("$projectDir/../docs/config.json")
 
     doLast {
         def parseStringsXml = { File xmlFile ->
@@ -184,9 +186,7 @@ tasks.register('generatePrefsDoc') {
             def root = parser.parse(xmlFile)
             def map = [:]
             root.string.each { s ->
-                def name = s.@name.toString()
-                def value = s.text().trim()
-                map[name] = value
+                map[s.@name.toString()] = s.text().trim()
             }
             return map
         }
@@ -198,8 +198,7 @@ tasks.register('generatePrefsDoc') {
             def map = [:]
             root.array.each { arr ->
                 def name = arr.@name.toString()
-                def items = arr.item.collect { it.text().trim() }
-                map[name] = items
+                map[name] = arr.item.collect { it.text().trim() }
             }
             return map
         }
@@ -220,8 +219,8 @@ tasks.register('generatePrefsDoc') {
             return ref
         }
 
-        def getAttrValue = { attrs, List<String> possibleKeys ->
-            for (k in possibleKeys) {
+        def getAttrValue = { attrs, List<String> keys ->
+            for (k in keys) {
                 if (attrs.containsKey(k)) {
                     return attrs[k]
                 }
@@ -230,6 +229,7 @@ tasks.register('generatePrefsDoc') {
         }
 
         def md = new StringBuilder("# Preferences Documentation\n\n")
+        def jsonList = [] // full JSON list to serialize
 
         resXmlDir.eachFile { xmlFile ->
             if (xmlFile.name.toLowerCase().startsWith("preference") && xmlFile.name.endsWith(".xml")) {
@@ -238,16 +238,36 @@ tasks.register('generatePrefsDoc') {
                         .replaceFirst(/\.xml$/, '')
                         .replaceAll(/_/, ' ')
                         .capitalize()
-                md.append("# ${logicalName}\n\n")
+
+                md.append("## ${logicalName}\n\n")
 
                 def xml = new XmlSlurper(false, false).parse(xmlFile)
+                def categories = [:]
 
-                def categories = [:]  // categoryName -> [summary, list of prefs]
 
                 def processPrefs
                 processPrefs = { node, categoryName = null ->
                     def attrs = node.attributes()
-
+                    def prefType
+                    switch (node.name()) {
+                        case "SwitchPreferenceCompat":
+                        case "SwitchPreference":
+                        case "CheckBoxPreference":
+                            prefType = "boolean"
+                            break
+                        case "EditTextPreference":
+                        case "ListPreference":
+                            prefType = "string"
+                            break
+                        case "SeekBarPreference":
+                            prefType = "int"
+                            break
+                        case "MultiSelectListPreference":
+                            prefType = "set"
+                            break
+                        default:
+                            prefType = "string"
+                    }
                     if (node.name() == "PreferenceCategory") {
                         def catTitleRaw = getAttrValue(attrs, ['android:title', 'app:title', 'title'])
                         def catSummaryRaw = getAttrValue(attrs, ['android:summary', 'app:summary', 'summary'])
@@ -287,7 +307,8 @@ tasks.register('generatePrefsDoc') {
                                     key         : keyRaw,
                                     title       : title,
                                     summary     : summary,
-                                    defaultValue: defaultValue
+                                    defaultValue: defaultValue,
+                                    type        : prefType
                             ]
                         }
                     }
@@ -295,8 +316,13 @@ tasks.register('generatePrefsDoc') {
 
                 processPrefs(xml)
 
+                def jsonEntry = [
+                        setting: logicalName.toLowerCase().replaceAll(" ", "_"),
+                        categories: []
+                ]
+
                 categories.each { catName, info ->
-                    md.append("## ${catName}\n\n")
+                    md.append("### ${catName}\n\n")
                     if (info.summary) {
                         md.append("_${info.summary}_\n\n")
                     }
@@ -310,14 +336,37 @@ tasks.register('generatePrefsDoc') {
                         md.append("| **${p.key}** | ${escTitle} | ${escSummary} | ${escDefault} |\n")
                     }
                     md.append("\n")
+
+                    jsonEntry.categories << [
+                            name: catName.replaceAll(" ", "_").toLowerCase(),
+                            preferences: info.prefs.collect { p -> [key: p.key, value: null, type: p.type] }
+                    ]
                 }
+
+                jsonList << jsonEntry
             }
         }
 
         outputFile.parentFile.mkdirs()
         outputFile.text = md.toString()
+
+        jsonList.add([
+                metadata: [
+                        version: android.defaultConfig.versionName,
+                        code   : android.defaultConfig.versionCode,
+                        gitHash: getGitHash()
+                ]
+        ])
+        def json = groovy.json.JsonOutput.prettyPrint(
+                groovy.json.JsonOutput.toJson(jsonList)
+        )
+
+
+        jsonOutputFile.text = json
+
         println "Preferences Markdown generated at: ${outputFile.path}"
+        println "Preferences JSON generated at: ${jsonOutputFile.path}"
     }
 }
 
-preBuild.dependsOn(generatePrefsDoc)
+preBuild.dependsOn(tasks.named("generatePrefsDoc"))

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,6 +5,8 @@
  * SPDX-License-Identifier: apache2
  */
 
+import groovy.xml.Namespace
+
 plugins {
     id 'com.android.application'
     id 'androidx.navigation.safeargs'
@@ -169,6 +171,156 @@ dependencies {
     implementation "com.squareup.moshi:moshi-adapters:1.15.2"
 }
 
-configurations.implementation {
-    exclude group: 'org.jetbrains.kotlin', module: 'kotlin-stdlib-jdk8'
+
+
+
+task generatePrefsDoc {
+    def resXmlDir = file("$projectDir/src/main/res/xml")
+    def stringsFile = file("$projectDir/src/main/res/values/strings.xml")
+    def arraysFile = file("$projectDir/src/main/res/values/arrays.xml")
+    def outputFile = file("$projectDir/../docs/preferences.md")
+
+    doLast {
+        def parseStringsXml = { File xmlFile ->
+            def parser = new XmlSlurper()
+            def root = parser.parse(xmlFile)
+            def map = [:]
+            root.string.each { s ->
+                def name = s.@name.toString()
+                def value = s.text().trim()
+                map[name] = value
+            }
+            return map
+        }
+
+        def parseArraysXml = { File xmlFile ->
+            if (!xmlFile.exists()) return [:]
+            def parser = new XmlSlurper()
+            def root = parser.parse(xmlFile)
+            def map = [:]
+            root.array.each { arr ->
+                def name = arr.@name.toString()
+                def items = arr.item.collect { it.text().trim() }
+                map[name] = items
+            }
+            return map
+        }
+
+        def stringsMap = stringsFile.exists() ? parseStringsXml(stringsFile) : [:]
+        def arraysMap = arraysFile.exists() ? parseArraysXml(arraysFile) : [:]
+
+        def resolveRef = { String ref ->
+            if (!ref) return ""
+            if (ref.startsWith("@string/")) {
+                def key = ref.substring(8)
+                return stringsMap.get(key, ref)
+            } else if (ref.startsWith("@array/")) {
+                def key = ref.substring(7)
+                def arr = arraysMap.get(key)
+                return arr ? arr.join(", ") : ref
+            }
+            return ref
+        }
+
+        def getAttrValue = { attrs, List<String> possibleKeys ->
+            for (k in possibleKeys) {
+                if (attrs.containsKey(k)) {
+                    return attrs[k]
+                }
+            }
+            return null
+        }
+
+        def md = new StringBuilder("# Preferences Documentation\n\n")
+
+        resXmlDir.eachFile { xmlFile ->
+            if (xmlFile.name.toLowerCase().startsWith("preference") && xmlFile.name.endsWith(".xml")) {
+                def logicalName = xmlFile.name
+                    .replaceFirst(/^preference_/, '')
+                    .replaceFirst(/\.xml$/, '')
+                    .replaceAll(/_/, ' ')
+                    .capitalize()
+                md.append("# ${logicalName}\n\n")
+
+                def xml = new XmlSlurper(false, false).parse(xmlFile)
+
+                def categories = [:]  // categoryName -> [summary, list of prefs]
+
+                def processPrefs
+                processPrefs = { node, categoryName = null ->
+                    def attrs = node.attributes()
+
+                    if (node.name() == "PreferenceCategory") {
+                        def catTitleRaw = getAttrValue(attrs, ['android:title', 'app:title', 'title'])
+                        def catSummaryRaw = getAttrValue(attrs, ['android:summary', 'app:summary', 'summary'])
+                        def catTitle = resolveRef(catTitleRaw) ?: "Unnamed Category"
+                        def catSummary = resolveRef(catSummaryRaw) ?: ""
+
+                        if (!categories.containsKey(catTitle)) {
+                            categories[catTitle] = [summary: catSummary, prefs: []]
+                        }
+
+                        node.children().each { child ->
+                            processPrefs(child, catTitle)
+                        }
+                    } else if (node.name() == "PreferenceScreen") {
+                        node.children().each { child ->
+                            processPrefs(child, categoryName)
+                        }
+                    } else {
+                        def keyRaw = getAttrValue(attrs, ['android:key', 'app:key', 'key'])
+                        if (keyRaw) {
+                            def titleRaw = getAttrValue(attrs, ['android:title', 'app:title', 'title'])
+                            def summaryRaw = getAttrValue(attrs, ['android:summary', 'app:summary', 'summary'])
+                            def defaultValueRaw = getAttrValue(attrs, ['android:defaultValue', 'app:defaultValue', 'defaultValue'])
+
+                            def title = resolveRef(titleRaw)
+                            def summary = resolveRef(summaryRaw)
+                            def defaultValue = resolveRef(defaultValueRaw)
+
+                            if (categoryName == null) {
+                                categoryName = "General Preferences"
+                                if (!categories.containsKey(categoryName)) {
+                                    categories[categoryName] = [summary: "", prefs: []]
+                                }
+                            }
+
+                            categories[categoryName].prefs << [
+                                    key: keyRaw,
+                                    title: title,
+                                    summary: summary,
+                                    defaultValue: defaultValue
+                            ]
+                        }
+                    }
+                }
+
+                processPrefs(xml)
+
+                categories.each { catName, info ->
+                    md.append("## ${catName}\n\n")
+                    if (info.summary) {
+                        md.append("_${info.summary}_\n\n")
+                    }
+
+                    md.append("| Key | Title | Summary | Default Value |\n")
+                    md.append("| --- | ----- | ------- | ------------- |\n")
+                    info.prefs.each { p ->
+                        def escTitle = p.title?.replaceAll("\\|", "\\\\|") ?: ""
+                        def escSummary = p.summary?.replaceAll("\\|", "\\\\|") ?: ""
+                        def escDefault = p.defaultValue ? "`${p.defaultValue.replaceAll("\\|", "\\\\|")}`" : ""
+                        md.append("| **${p.key}** | ${escTitle} | ${escSummary} | ${escDefault} |\n")
+                    }
+                    md.append("\n")
+                }
+            }
+        }
+
+        outputFile.parentFile.mkdirs()
+        outputFile.text = md.toString()
+        println "Preferences Markdown generated at: ${outputFile.path}"
+    }
 }
+
+
+

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -178,7 +178,8 @@ tasks.register('generatePrefsDoc') {
     def stringsFile = file("$projectDir/src/main/res/values/strings.xml")
     def arraysFile = file("$projectDir/src/main/res/values/arrays.xml")
     def outputFile = file("$projectDir/../docs/preferences.md")
-    def jsonOutputFile = file("$projectDir/../docs/config.json")
+    def jsonOutputFileDoc = file("$projectDir/../docs/config.json")
+    def jsonOutputFileResources = file("$projectDir/src/main/res/raw/config.json")
 
     doLast {
         def parseStringsXml = { File xmlFile ->
@@ -306,6 +307,7 @@ tasks.register('generatePrefsDoc') {
                             categories[categoryName].prefs << [
                                     key         : keyRaw,
                                     title       : title,
+                                    nodeName   : node.name(),
                                     summary     : summary,
                                     defaultValue: defaultValue,
                                     type        : prefType
@@ -336,11 +338,16 @@ tasks.register('generatePrefsDoc') {
                         md.append("| **${p.key}** | ${escTitle} | ${escSummary} | ${escDefault} |\n")
                     }
                     md.append("\n")
-
-                    jsonEntry.categories << [
-                            name: catName.replaceAll(" ", "_").toLowerCase(),
-                            preferences: info.prefs.collect { p -> [key: p.key, value: null, type: p.type] }
-                    ]
+                    jsonEntry.categories += info.prefs
+                            .findAll { p -> p.nodeName != "Preference" && p.key?.trim() }
+                            .groupBy { catName.replaceAll(" ", "_").toLowerCase() }
+                            .collect { cat, prefs ->
+                                [
+                                        name: cat,
+                                        preferences: prefs.collect { p -> [key: p.key, value: null, type: p.type] }
+                                ]
+                            }
+                            .findAll { it.preferences }
                 }
 
                 jsonList << jsonEntry
@@ -362,10 +369,11 @@ tasks.register('generatePrefsDoc') {
         )
 
 
-        jsonOutputFile.text = json
+        jsonOutputFileDoc.text = json
+        jsonOutputFileResources.text = json
 
         println "Preferences Markdown generated at: ${outputFile.path}"
-        println "Preferences JSON generated at: ${jsonOutputFile.path}"
+        println "Preferences JSON generated at: ${jsonOutputFileDoc.path}"
     }
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -172,9 +172,7 @@ dependencies {
 }
 
 
-
-
-task generatePrefsDoc {
+tasks.register('generatePrefsDoc') {
     def resXmlDir = file("$projectDir/src/main/res/xml")
     def stringsFile = file("$projectDir/src/main/res/values/strings.xml")
     def arraysFile = file("$projectDir/src/main/res/values/arrays.xml")
@@ -236,10 +234,10 @@ task generatePrefsDoc {
         resXmlDir.eachFile { xmlFile ->
             if (xmlFile.name.toLowerCase().startsWith("preference") && xmlFile.name.endsWith(".xml")) {
                 def logicalName = xmlFile.name
-                    .replaceFirst(/^preference_/, '')
-                    .replaceFirst(/\.xml$/, '')
-                    .replaceAll(/_/, ' ')
-                    .capitalize()
+                        .replaceFirst(/^preference_/, '')
+                        .replaceFirst(/\.xml$/, '')
+                        .replaceAll(/_/, ' ')
+                        .capitalize()
                 md.append("# ${logicalName}\n\n")
 
                 def xml = new XmlSlurper(false, false).parse(xmlFile)
@@ -286,9 +284,9 @@ task generatePrefsDoc {
                             }
 
                             categories[categoryName].prefs << [
-                                    key: keyRaw,
-                                    title: title,
-                                    summary: summary,
+                                    key         : keyRaw,
+                                    title       : title,
+                                    summary     : summary,
                                     defaultValue: defaultValue
                             ]
                         }
@@ -322,5 +320,4 @@ task generatePrefsDoc {
     }
 }
 
-
-
+preBuild.dependsOn(generatePrefsDoc)

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/DataProvider/DataProvider.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/DataProvider/DataProvider.java
@@ -403,7 +403,7 @@ public class DataProvider extends TelephonyCallback implements LocationListener,
     @SuppressLint("ObsoleteSdkInt")
     public List<Point> getCellInformationPoint() {
         List<Point> points = new ArrayList<>();
-        boolean nc = spg.getSharedPreference(SPType.logging_sp).getBoolean("log_neighbour_cells", false);
+        boolean nc = spg.getSharedPreference(SPType.LOGGING).getBoolean("log_neighbour_cells", false);
         for (CellInformation ci_ : ci) {
             // check if want to log neighbour cells and skip non registered cells
             if (!nc) {
@@ -612,7 +612,7 @@ public class DataProvider extends TelephonyCallback implements LocationListener,
         point.time(System.currentTimeMillis(), WritePrecision.MS);
         // falling back to fake if no location is available is not the best solution.
         // We should ask the user / add configuration what to do
-        if (spg.getSharedPreference(SPType.logging_sp).getBoolean("fake_location", false) || li == null) {
+        if (spg.getSharedPreference(SPType.LOGGING).getBoolean("fake_location", false) || li == null) {
             point.addField("longitude", 13.3143266);
             point.addField("latitude", 52.5259678);
             point.addField("altitude", 34.0);
@@ -719,7 +719,7 @@ public class DataProvider extends TelephonyCallback implements LocationListener,
      */
     @SuppressLint("ObsoleteSdkInt")
     public Map<String, String> getTagsMap() {
-        String tags = spg.getSharedPreference(SPType.logging_sp).getString("tags", "").strip().replace(" ", "");
+        String tags = spg.getSharedPreference(SPType.LOGGING).getString("tags", "").strip().replace(" ", "");
         Map<String, String> tags_map = Collections.emptyMap();
         if (!tags.isEmpty()) {
             try {
@@ -731,13 +731,13 @@ public class DataProvider extends TelephonyCallback implements LocationListener,
         DeviceInformation di = getDeviceInformation();
 
         Map<String, String> tags_map_modifiable = new HashMap<>(tags_map);
-        tags_map_modifiable.put("measurement_name", spg.getSharedPreference(SPType.logging_sp).getString("measurement_name", "OMNT"));
+        tags_map_modifiable.put("measurement_name", spg.getSharedPreference(SPType.LOGGING).getString("measurement_name", "OMNT"));
         tags_map_modifiable.put("manufacturer", di.getManufacturer());
         tags_map_modifiable.put("model", di.getModel());
         tags_map_modifiable.put("sdk_version", String.valueOf(di.getAndroidSDK()));
         tags_map_modifiable.put("android_version", di.getAndroidRelease());
         tags_map_modifiable.put("security_patch", di.getSecurityPatchLevel());
-        String device = spg.getSharedPreference(SPType.default_sp).getString("device_name", "null").strip();
+        String device = spg.getSharedPreference(SPType.MAIN).getString("device_name", "null").strip();
         //if(device.equals("null")); TODO handle this
         tags_map_modifiable.put("device", device);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/DetailFragment.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/DetailFragment.java
@@ -489,7 +489,7 @@ public class DetailFragment extends Fragment {
         List<CellInformation> cil = dp.getCellInformation();
         int cell = 1;
         for (CellInformation ci : cil) {
-            if (!spg.getSharedPreference(SPType.default_sp).getBoolean("show_neighbour_cells", false) && !ci.isRegistered()) {
+            if (!spg.getSharedPreference(SPType.MAIN).getBoolean("show_neighbour_cells", false) && !ci.isRegistered()) {
                 continue;
             }
             TableRow title = rowBuilder("Cell " + cell, "");

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/InfluxDB2x/InfluxdbConnection.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/InfluxDB2x/InfluxdbConnection.java
@@ -71,19 +71,19 @@ public class InfluxdbConnection {
             writeApi.listenEvents(BackpressureEvent.class, value -> Log.d(TAG, "open_write_api: Could not write to InfluxDBv2 due to backpressure"));
             writeApi.listenEvents(WriteSuccessEvent.class, value -> {
                 //Log.d(TAG, "open_write_api: Write to InfluxDBv2 was successful");
-                if ( spg.getSharedPreference(SPType.logging_sp).getBoolean("enable_influx", false)) {
+                if ( spg.getSharedPreference(SPType.LOGGING).getBoolean("enable_influx", false)) {
                     gv.getLog_status().setColorFilter(Color.argb(255, 0, 255, 0));
                 }
             });
             writeApi.listenEvents(WriteErrorEvent.class, value -> {
                 Log.d(TAG, "open_write_api: Could not write to InfluxDBv2 due to error");
-                if ( spg.getSharedPreference(SPType.logging_sp).getBoolean("enable_influx", false)) {
+                if ( spg.getSharedPreference(SPType.LOGGING).getBoolean("enable_influx", false)) {
                     gv.getLog_status().setColorFilter(Color.argb(255, 255, 0, 0));
                 }
             });
             writeApi.listenEvents(WriteRetriableErrorEvent.class, value -> {
                 Log.d(TAG, "open_write_api: Could not write to InfluxDBv2 due to retriable error");
-                if ( spg.getSharedPreference(SPType.logging_sp).getBoolean("enable_influx", false)) {
+                if ( spg.getSharedPreference(SPType.LOGGING).getBoolean("enable_influx", false)) {
                     gv.getLog_status().setColorFilter(Color.argb(255, 255, 0, 0));
                 }
             });

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/InfluxDB2x/InfluxdbConnections.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/InfluxDB2x/InfluxdbConnections.java
@@ -28,10 +28,10 @@ public class InfluxdbConnections {
     public static InfluxdbConnection getRicInstance(Context context) {
         if (ric == null) {
             SharedPreferencesGrouper spg = SharedPreferencesGrouper.getInstance(context);
-            String url = spg.getSharedPreference(SPType.logging_sp).getString("influx_URL", "");
-            String org = spg.getSharedPreference(SPType.logging_sp).getString("influx_org", "");
-            String bucket = spg.getSharedPreference(SPType.logging_sp).getString("influx_bucket", "");
-            String token = spg.getSharedPreference(SPType.logging_sp).getString("influx_token", "");
+            String url = spg.getSharedPreference(SPType.LOGGING).getString("influx_URL", "");
+            String org = spg.getSharedPreference(SPType.LOGGING).getString("influx_org", "");
+            String bucket = spg.getSharedPreference(SPType.LOGGING).getString("influx_bucket", "");
+            String token = spg.getSharedPreference(SPType.LOGGING).getString("influx_token", "");
             if (url.isEmpty() || org.isEmpty() || bucket.isEmpty() || token.isEmpty()) {
                 Log.e(TAG, "Influx parameters incomplete, can't setup logging");
                 // if we are an UI thread we make a toast, if not logging have to be enough

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Iperf3/Fragments/Iperf3Fragment.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Iperf3/Fragments/Iperf3Fragment.java
@@ -132,7 +132,7 @@ public class Iperf3Fragment extends Fragment {
             @Override
             public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
                 consumer.accept(charSequence.toString());
-                spg.getSharedPreference(SPType.iperf3_sp).edit().putString(name, charSequence.toString()).apply();
+                spg.getSharedPreference(SPType.IPERF3).edit().putString(name, charSequence.toString()).apply();
             }
 
             @Override
@@ -161,8 +161,8 @@ public class Iperf3Fragment extends Fragment {
      * @param key
      */
     private void setTextFromSharedPreferences(TextInputEditText editText, String key) {
-        if (spg.getSharedPreference(SPType.iperf3_sp).contains(key)) {
-            editText.setText(spg.getSharedPreference(SPType.iperf3_sp).getString(key, ""));
+        if (spg.getSharedPreference(SPType.IPERF3).contains(key)) {
+            editText.setText(spg.getSharedPreference(SPType.IPERF3).getString(key, ""));
         }
     }
 
@@ -368,7 +368,7 @@ public class Iperf3Fragment extends Fragment {
         setupTextWatchers();
         setTextsFromSharedPreferences();
         try {
-            switch (Iperf3Parameter.Iperf3Mode.valueOf(spg.getSharedPreference(SPType.iperf3_sp).getString(Iperf3Parameter.MODE, String.valueOf(Iperf3Parameter.Iperf3Mode.UNDEFINED)))){
+            switch (Iperf3Parameter.Iperf3Mode.valueOf(spg.getSharedPreference(SPType.IPERF3).getString(Iperf3Parameter.MODE, String.valueOf(Iperf3Parameter.Iperf3Mode.UNDEFINED)))){
                 case CLIENT:
                     updateModeState(modeClient, modeServer, Iperf3Parameter.Iperf3Mode.CLIENT);
                     break;
@@ -379,14 +379,14 @@ public class Iperf3Fragment extends Fragment {
                 default:
                     modeClient.setBackgroundColor(Color.TRANSPARENT);
                     modeServer.setBackgroundColor(Color.TRANSPARENT);
-                    spg.getSharedPreference(SPType.iperf3_sp).edit().putString(Iperf3Parameter.MODE, Iperf3Parameter.Iperf3Mode.UNDEFINED.toString()).apply();
+                    spg.getSharedPreference(SPType.IPERF3).edit().putString(Iperf3Parameter.MODE, Iperf3Parameter.Iperf3Mode.UNDEFINED.toString()).apply();
                     break;
             }
         } catch (IllegalArgumentException e) {
             Log.e(TAG, "onCreateView: ", e);
         }
         try {
-            switch (Iperf3Parameter.Iperf3Protocol.valueOf(spg.getSharedPreference(SPType.iperf3_sp).getString(Iperf3Parameter.PROTOCOL, Iperf3Parameter.Iperf3Protocol.UNDEFINED.toString()))){
+            switch (Iperf3Parameter.Iperf3Protocol.valueOf(spg.getSharedPreference(SPType.IPERF3).getString(Iperf3Parameter.PROTOCOL, Iperf3Parameter.Iperf3Protocol.UNDEFINED.toString()))){
                 case TCP:
                     updateProtocolState(protocolTCP, protocolUDP, Iperf3Parameter.Iperf3Protocol.TCP);
                     break;
@@ -397,14 +397,14 @@ public class Iperf3Fragment extends Fragment {
                 default:
                     protocolTCP.setBackgroundColor(Color.TRANSPARENT);
                     protocolUDP.setBackgroundColor(Color.TRANSPARENT);
-                    spg.getSharedPreference(SPType.iperf3_sp).edit().putString(Iperf3Parameter.PROTOCOL, Iperf3Parameter.Iperf3Protocol.UNDEFINED.toString()).apply();
+                    spg.getSharedPreference(SPType.IPERF3).edit().putString(Iperf3Parameter.PROTOCOL, Iperf3Parameter.Iperf3Protocol.UNDEFINED.toString()).apply();
                     break;
             }
         } catch (IllegalArgumentException e) {
             Log.e(TAG, "onCreateView: ", e);
         }
         try {
-            switch (Iperf3Parameter.Iperf3Direction.valueOf(spg.getSharedPreference(SPType.iperf3_sp).getString(Iperf3Parameter.DIRECTION, Iperf3Parameter.Iperf3Direction.UNDEFINED.toString()))) {
+            switch (Iperf3Parameter.Iperf3Direction.valueOf(spg.getSharedPreference(SPType.IPERF3).getString(Iperf3Parameter.DIRECTION, Iperf3Parameter.Iperf3Direction.UNDEFINED.toString()))) {
                 case UP:
                     updateDirectionState(directionUp, directionDown, directonBidir, Iperf3Parameter.Iperf3Direction.UP);
                     break;
@@ -495,14 +495,14 @@ public class Iperf3Fragment extends Fragment {
         activeButton.setBackgroundColor(getResources().getColor(R.color.purple_500, null));
         inactiveButton.setBackgroundColor(Color.TRANSPARENT);
         iperf3Input.getParameter().setMode(protocol);
-        spg.getSharedPreference(SPType.iperf3_sp).edit().putString(Iperf3Parameter.MODE, protocol.toString()).apply();
+        spg.getSharedPreference(SPType.IPERF3).edit().putString(Iperf3Parameter.MODE, protocol.toString()).apply();
     }
 
     private void updateProtocolState(MaterialButton activeButton, MaterialButton inactiveButton, Iperf3Parameter.Iperf3Protocol protocol) {
         activeButton.setBackgroundColor(getResources().getColor(R.color.purple_500, null));
         inactiveButton.setBackgroundColor(Color.TRANSPARENT);
         iperf3Input.getParameter().setProtocol(protocol);
-        spg.getSharedPreference(SPType.iperf3_sp).edit().putString(Iperf3Parameter.PROTOCOL, protocol.toString()).apply();
+        spg.getSharedPreference(SPType.IPERF3).edit().putString(Iperf3Parameter.PROTOCOL, protocol.toString()).apply();
     }
 
     private void updateDirectionState(MaterialButton activeButton, MaterialButton inactiveButton1, MaterialButton inactiveButton2, Iperf3Parameter.Iperf3Direction direction) {
@@ -510,6 +510,6 @@ public class Iperf3Fragment extends Fragment {
         inactiveButton1.setBackgroundColor(Color.TRANSPARENT);
         inactiveButton2.setBackgroundColor(Color.TRANSPARENT);
         iperf3Input.getParameter().setDirection(direction);
-        spg.getSharedPreference(SPType.iperf3_sp).edit().putString(Iperf3Parameter.DIRECTION, direction.toString()).apply();
+        spg.getSharedPreference(SPType.IPERF3).edit().putString(Iperf3Parameter.DIRECTION, direction.toString()).apply();
     }
 }

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Iperf3/Iperf3Executor.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Iperf3/Iperf3Executor.java
@@ -11,7 +11,6 @@ package de.fraunhofer.fokus.OpenMobileNetworkToolkit.Iperf3;
 import android.annotation.SuppressLint;
 import android.content.Context;
 
-import androidx.work.Constraints;
 import androidx.work.OneTimeWorkRequest;
 import androidx.work.WorkContinuation;
 import androidx.work.WorkManager;
@@ -19,9 +18,7 @@ import androidx.work.multiprocess.RemoteWorkContinuation;
 import androidx.work.multiprocess.RemoteWorkManager;
 
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.concurrent.TimeUnit;
 
 import de.fraunhofer.fokus.OpenMobileNetworkToolkit.InfluxDB2x.Worker.InfluxDB2xUploadWorker;
 import de.fraunhofer.fokus.OpenMobileNetworkToolkit.Inputs.Iperf3Input;
@@ -73,7 +70,7 @@ public class Iperf3Executor {
 
 
         this.remoteWorkContinuation = this.remoteWorkManager.beginWith(Arrays.asList(iperf3ExecutorWorker, iperf3MonitorWorker)).then(iPerf3ToLineProtocolWorker);
-        if(spg.getSharedPreference(SPType.logging_sp).getBoolean("enable_influx", false)){
+        if(spg.getSharedPreference(SPType.LOGGING).getBoolean("enable_influx", false)){
             this.remoteWorkContinuation = remoteWorkContinuation.then(influxDB2xUploadWorker);
         }
     }

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/LoggingService.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/LoggingService.java
@@ -159,7 +159,7 @@ public class LoggingService extends Service {
         s.append(getText(R.string.loggin_notifaction)).append("\n");
         s.append("Logging to...\n");
 
-        if(spg.getSharedPreference(SPType.logging_sp).getBoolean("enable_local_file_log", false))
+        if(spg.getSharedPreference(SPType.LOGGING).getBoolean("enable_local_file_log", false))
             s.append("File\n");
 
         if(ic == null) {
@@ -262,7 +262,7 @@ public class LoggingService extends Service {
     }
 
     private void handleWriteApiEvent(InfluxdbWriteApiStatus status, String message) {
-        if (!spg.getSharedPreference(SPType.logging_sp).getBoolean("enable_influx", false)) return;
+        if (!spg.getSharedPreference(SPType.LOGGING).getBoolean("enable_influx", false)) return;
 
         // Check if status has changed
         if (currentInfluxdbWriteApiStatus == status &&
@@ -288,7 +288,7 @@ public class LoggingService extends Service {
         dp = gv.get_dp();
         nm = getSystemService(NotificationManager.class);
         spg = SharedPreferencesGrouper.getInstance(this);
-        interval = Integer.parseInt(spg.getSharedPreference(SPType.logging_sp).getString("logging_interval", "1000"));
+        interval = Integer.parseInt(spg.getSharedPreference(SPType.LOGGING).getString("logging_interval", "1000"));
 
 
 
@@ -298,11 +298,11 @@ public class LoggingService extends Service {
             if(Objects.equals(key, "enable_logging")) {
                 if (prefs.getBoolean(key, false)) {
                     Log.d(TAG, "onSharedPreferenceChanged: " + prefs.getBoolean(key, false));
-                    if(spg.getSharedPreference(SPType.logging_sp).getBoolean("enable_influx", false)) {
+                    if(spg.getSharedPreference(SPType.LOGGING).getBoolean("enable_influx", false)) {
                         // enable influx when enable_logging is enabled
                         setupRemoteInfluxDB();
                     }
-                    if(spg.getSharedPreference(SPType.logging_sp).getBoolean("enable_local_file_log", false)){
+                    if(spg.getSharedPreference(SPType.LOGGING).getBoolean("enable_local_file_log", false)){
                         // enable local file log when enable_logging is enabled
                         setupLocalFile();
                         updateNotification();
@@ -321,7 +321,7 @@ public class LoggingService extends Service {
                         Toast.makeText(getApplicationContext(), "Please fill all Influx Settings", Toast.LENGTH_LONG).show();
                         prefs.edit().putBoolean("enable_influx", false).apply();
                     } else {
-                        if(spg.getSharedPreference(SPType.logging_sp).getBoolean("enable_logging", false)) {
+                        if(spg.getSharedPreference(SPType.LOGGING).getBoolean("enable_logging", false)) {
                             // only enable influx log, when enable_logging is also enabled
                             setupRemoteInfluxDB();
                             updateNotification();
@@ -329,7 +329,7 @@ public class LoggingService extends Service {
 
                     }
                 } else {
-                    if(spg.getSharedPreference(SPType.logging_sp).getBoolean("enable_logging", false)) {
+                    if(spg.getSharedPreference(SPType.LOGGING).getBoolean("enable_logging", false)) {
                         // only stop influx log, when enable_logging is also enabled
                         stopRemoteInfluxDB();
                         updateNotification();
@@ -338,13 +338,13 @@ public class LoggingService extends Service {
                 }
             } else if (Objects.equals(key, "enable_local_file_log")) {
                 if (prefs.getBoolean(key, false)) {
-                    if(spg.getSharedPreference(SPType.logging_sp).getBoolean("enable_logging", false)) {
+                    if(spg.getSharedPreference(SPType.LOGGING).getBoolean("enable_logging", false)) {
                         // only enable file log, when enable_logging is also enabled
                         setupLocalFile();
                         updateNotification();
                     }
                 } else {
-                    if(spg.getSharedPreference(SPType.logging_sp).getBoolean("enable_logging", false)) {
+                    if(spg.getSharedPreference(SPType.LOGGING).getBoolean("enable_logging", false)) {
                         // only stop file log, when enable_logging is also enabled
                         stopLocalFile();
                         updateNotification();
@@ -357,19 +357,19 @@ public class LoggingService extends Service {
                     stopLocalInfluxDB();
                 }
             } else if (Objects.equals(key, "logging_interval")) {
-                interval = Integer.parseInt(spg.getSharedPreference(SPType.logging_sp).getString("logging_interval", "1000"));
+                interval = Integer.parseInt(spg.getSharedPreference(SPType.LOGGING).getString("logging_interval", "1000"));
             }
-        }, SPType.logging_sp);
+        }, SPType.LOGGING);
 
-        if (spg.getSharedPreference(SPType.logging_sp).getBoolean("enable_influx", false)) {
+        if (spg.getSharedPreference(SPType.LOGGING).getBoolean("enable_influx", false)) {
             setupRemoteInfluxDB();
         }
 
-        if (spg.getSharedPreference(SPType.logging_sp).getBoolean("enable_local_file_log", false)) {
+        if (spg.getSharedPreference(SPType.LOGGING).getBoolean("enable_local_file_log", false)) {
             setupLocalFile();
         }
 
-        if (spg.getSharedPreference(SPType.logging_sp).getBoolean("enable_local_influx_log", false)) {
+        if (spg.getSharedPreference(SPType.LOGGING).getBoolean("enable_local_influx_log", false)) {
             //TODO
         }
 
@@ -385,14 +385,14 @@ public class LoggingService extends Service {
     public void onDestroy() {
         super.onDestroy();
         Log.d(TAG, "onDestroy: Stop logging service");
-        if (spg.getSharedPreference(SPType.logging_sp).getBoolean("enable_influx", false)) {
+        if (spg.getSharedPreference(SPType.LOGGING).getBoolean("enable_influx", false)) {
             stopRemoteInfluxDB();
         }
 
-        if (spg.getSharedPreference(SPType.logging_sp).getBoolean("enable_local_file_log", false)) {
+        if (spg.getSharedPreference(SPType.LOGGING).getBoolean("enable_local_file_log", false)) {
             stopLocalFile();
         }
-        if (spg.getSharedPreference(SPType.logging_sp).getBoolean("enable_local_influx_log", false)) {
+        if (spg.getSharedPreference(SPType.LOGGING).getBoolean("enable_local_influx_log", false)) {
             stopLocalInfluxDB();
         }
 
@@ -410,7 +410,7 @@ public class LoggingService extends Service {
         if (dp != null) {
             Map<String, String> tags_map = dp.getTagsMap();
 
-            if (spg.getSharedPreference(SPType.logging_sp).getBoolean("influx_network_data", false)) {
+            if (spg.getSharedPreference(SPType.LOGGING).getBoolean("influx_network_data", false)) {
                 Point p = dp.getNetworkInformationPoint();
                 if (p.hasFields()) {
                     p.time(time, WritePrecision.MS);
@@ -421,7 +421,7 @@ public class LoggingService extends Service {
                 }
             }
 
-            if (spg.getSharedPreference(SPType.logging_sp).getBoolean("influx_throughput_data", false)) {
+            if (spg.getSharedPreference(SPType.LOGGING).getBoolean("influx_throughput_data", false)) {
                 Point p = dp.getNetworkCapabilitiesPoint();
                 if (p.hasFields()) {
                     p.time(time, WritePrecision.MS);
@@ -432,7 +432,7 @@ public class LoggingService extends Service {
                 }
             }
 
-            if (spg.getSharedPreference(SPType.logging_sp).getBoolean("log_signal_data", false)) {
+            if (spg.getSharedPreference(SPType.LOGGING).getBoolean("log_signal_data", false)) {
                 Point p = dp.getSignalStrengthPoint();
                 if (p.hasFields()) {
                     p.time(time, WritePrecision.MS);
@@ -443,7 +443,7 @@ public class LoggingService extends Service {
                 }
             }
 
-            if (spg.getSharedPreference(SPType.logging_sp).getBoolean("log_wifi_data", false)) {
+            if (spg.getSharedPreference(SPType.LOGGING).getBoolean("log_wifi_data", false)) {
                 WifiInformation wifiInformation = dp.getWifiInformation();
                 if (wifiInformation != null) {
                     Point p = wifiInformation.getWifiInformationPoint();
@@ -457,7 +457,7 @@ public class LoggingService extends Service {
                 }
             }
 
-            if (spg.getSharedPreference(SPType.logging_sp).getBoolean("influx_cell_data", false)) {
+            if (spg.getSharedPreference(SPType.LOGGING).getBoolean("influx_cell_data", false)) {
                 List<Point> ps = dp.getCellInformationPoint();
                 for (Point p : ps) {
                     if (p.hasFields()) {
@@ -470,7 +470,7 @@ public class LoggingService extends Service {
                 logPoints.addAll(ps);
             }
 
-            if (spg.getSharedPreference(SPType.logging_sp).getBoolean("influx_ip_address_data", false)) {
+            if (spg.getSharedPreference(SPType.LOGGING).getBoolean("influx_ip_address_data", false)) {
                 List<Point> ps = dp.getNetworkInterfaceInformationPoints();
                 for (Point p : ps) {
                     if (p.hasFields()) {
@@ -483,7 +483,7 @@ public class LoggingService extends Service {
                 logPoints.addAll(ps);
             }
 
-            if (spg.getSharedPreference(SPType.logging_sp).getBoolean("influx_battery_data", false)) {
+            if (spg.getSharedPreference(SPType.LOGGING).getBoolean("influx_battery_data", false)) {
                 Point bp = dp.getBatteryInformationPoint();
                 bp.time(time, WritePrecision.MS);
                 bp.addTags(tags_map);

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/LoggingServiceOnBootReceiver.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/LoggingServiceOnBootReceiver.java
@@ -22,8 +22,8 @@ public class LoggingServiceOnBootReceiver extends BroadcastReceiver {
     public void onReceive(Context context, Intent intent) {
         if (Intent.ACTION_BOOT_COMPLETED.equals(intent.getAction())) {
             spg = SharedPreferencesGrouper.getInstance(context);
-            if (spg.getSharedPreference(SPType.logging_sp).getBoolean("start_logging_on_boot", false) &&
-                spg.getSharedPreference(SPType.logging_sp).getBoolean("enable_logging", false)) {
+            if (spg.getSharedPreference(SPType.LOGGING).getBoolean("start_logging_on_boot", false) &&
+                spg.getSharedPreference(SPType.LOGGING).getBoolean("enable_logging", false)) {
                 Intent serviceIntent = new Intent(context, LoggingService.class);
                 context.startService(serviceIntent);
             }

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/MQTT/MQTTService.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/MQTT/MQTTService.java
@@ -24,7 +24,6 @@ import android.util.Log;
 import androidx.annotation.Nullable;
 import androidx.core.app.NotificationCompat;
 import androidx.work.Data;
-import androidx.work.ExistingWorkPolicy;
 import androidx.work.OneTimeWorkRequest;
 import androidx.work.WorkInfo;
 import androidx.work.multiprocess.RemoteWorkManager;
@@ -35,9 +34,6 @@ import com.hivemq.client.mqtt.mqtt5.Mqtt5AsyncClient;
 import com.hivemq.client.mqtt.mqtt5.Mqtt5Client;
 import com.hivemq.client.mqtt.mqtt5.message.connect.connack.Mqtt5ConnAck;
 import com.hivemq.client.mqtt.mqtt5.message.publish.Mqtt5PayloadFormatIndicator;
-import com.influxdb.client.domain.Run;
-
-import org.json.JSONObject;
 
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
@@ -78,7 +74,7 @@ public class MQTTService extends Service {
 
     private void setupSharedPreferences(){
         spg = SharedPreferencesGrouper.getInstance(context);
-        mqttSP = spg.getSharedPreference(SPType.mqtt_sp);
+        mqttSP = spg.getSharedPreference(SPType.MQTT);
         mqttSP.registerOnSharedPreferenceChangeListener((sharedPreferences, key) -> {
             if(key == null) return;
             if (key.equals("mqtt_host")) {
@@ -138,7 +134,7 @@ public class MQTTService extends Service {
 
     private void createNotification(){
         StringBuilder s = new StringBuilder();
-        String address = spg.getSharedPreference(SPType.mqtt_sp).getString("mqtt_host", "None");
+        String address = spg.getSharedPreference(SPType.MQTT).getString("mqtt_host", "None");
         if(address.equals("None")){
             s.append("MQTT Host: None\n");
         } else {
@@ -243,50 +239,50 @@ public class MQTTService extends Service {
         // config logging service
         if(topic.contains("/logging/enable")){
             Log.d(TAG, "handleConfigMessage: Enable Logging: " + payload);
-            spg.getSharedPreference(SPType.logging_sp).edit().putBoolean("enable_logging", parseBoolean(payload)).apply();
+            spg.getSharedPreference(SPType.LOGGING).edit().putBoolean("enable_logging", parseBoolean(payload)).apply();
             return;
         }
 
         if(topic.contains("/logging/start_on_boot")){
             Log.d(TAG, "handleConfigMessage: Start on Boot: " + payload);
-            spg.getSharedPreference(SPType.logging_sp).edit().putBoolean("start_logging_on_boot", parseBoolean(payload)).apply();
+            spg.getSharedPreference(SPType.LOGGING).edit().putBoolean("start_logging_on_boot", parseBoolean(payload)).apply();
             return;
         }
         if(topic.contains("/logging/notification_update_enabled")){
             Log.d(TAG, "handleConfigMessage: Notification Update: " + payload);
-            spg.getSharedPreference(SPType.logging_sp).edit().putBoolean("enable_notification_update", parseBoolean(payload)).apply();
+            spg.getSharedPreference(SPType.LOGGING).edit().putBoolean("enable_notification_update", parseBoolean(payload)).apply();
             return;
         }
         if(topic.contains("/logging/interval_ms")){
             Log.d(TAG, "handleConfigMessage: Logging Interval: " + payload);
-            spg.getSharedPreference(SPType.logging_sp).edit().putString("logging_interval", payload).apply();
+            spg.getSharedPreference(SPType.LOGGING).edit().putString("logging_interval", payload).apply();
             return;
         }
 
         // config influxdv_v2 parameter
         if(topic.contains("/influxv2/enabled")){
             Log.d(TAG, "handleConfigMessage: Enable Influx: " + payload);
-            spg.getSharedPreference(SPType.logging_sp).edit().putBoolean("enable_influx", parseBoolean(payload)).apply();
+            spg.getSharedPreference(SPType.LOGGING).edit().putBoolean("enable_influx", parseBoolean(payload)).apply();
             return;
         }
         if(topic.contains("/influxv2/address")){
             Log.d(TAG, "handleConfigMessage: Influx Address: " + payload);
-            spg.getSharedPreference(SPType.logging_sp).edit().putString("influx_URL", payload).apply();
+            spg.getSharedPreference(SPType.LOGGING).edit().putString("influx_URL", payload).apply();
             return;
         }
         if(topic.contains("/influxv2/token")){
             Log.d(TAG, "handleConfigMessage: Influx Token received!");
-            spg.getSharedPreference(SPType.logging_sp).edit().putString("influx_token", payload).apply();
+            spg.getSharedPreference(SPType.LOGGING).edit().putString("influx_token", payload).apply();
             return;
         }
         if(topic.contains("/influxv2/bucket")){
             Log.d(TAG, "handleConfigMessage: Influx Bucket: " + payload);
-            spg.getSharedPreference(SPType.logging_sp).edit().putString("influx_bucket", payload).apply();
+            spg.getSharedPreference(SPType.LOGGING).edit().putString("influx_bucket", payload).apply();
             return;
         }
         if(topic.contains("/influxv2/org")){
             Log.d(TAG, "handleConfigMessage: Influx Org: " + payload);
-            spg.getSharedPreference(SPType.logging_sp).edit().putString("influx_org", payload).apply();
+            spg.getSharedPreference(SPType.LOGGING).edit().putString("influx_org", payload).apply();
             return;
         }
         if(topic.contains("/influxv2/tags")){
@@ -300,54 +296,54 @@ public class MQTTService extends Service {
         // config log file
         if(topic.contains("/file/enabled")){
             Log.d(TAG, "handleConfigMessage: Enable Local File Log: " + payload);
-            spg.getSharedPreference(SPType.logging_sp).edit().putBoolean("enable_local_file_log", parseBoolean(payload)).apply();
+            spg.getSharedPreference(SPType.LOGGING).edit().putBoolean("enable_local_file_log", parseBoolean(payload)).apply();
             return;
         }
 
         // config logging content
         if(topic.contains("/content/measurement_name")){
             Log.d(TAG, "handleConfigMessage: Measurement Name: " + payload);
-            spg.getSharedPreference(SPType.logging_sp).edit().putString("measurement_name", payload).apply();
+            spg.getSharedPreference(SPType.LOGGING).edit().putString("measurement_name", payload).apply();
             return;
         }
         if(topic.contains("/content/network_information")){
             Log.d(TAG, "handleConfigMessage: Network Information: " + payload);
-            spg.getSharedPreference(SPType.logging_sp).edit().putBoolean("influx_network_data", parseBoolean(payload)).apply();
+            spg.getSharedPreference(SPType.LOGGING).edit().putBoolean("influx_network_data", parseBoolean(payload)).apply();
             return;
         }
         if(topic.contains("/content/signal_information")){
             Log.d(TAG, "handleConfigMessage: Signal Information: " + payload);
-            spg.getSharedPreference(SPType.logging_sp).edit().putBoolean("log_signal_data", parseBoolean(payload)).apply();
+            spg.getSharedPreference(SPType.LOGGING).edit().putBoolean("log_signal_data", parseBoolean(payload)).apply();
             return;
         }
         if(topic.contains("/content/cell_information")){
             Log.d(TAG, "handleConfigMessage: Cell Information: " + payload);
-            spg.getSharedPreference(SPType.logging_sp).edit().putBoolean("influx_cell_data", parseBoolean(payload)).apply();
+            spg.getSharedPreference(SPType.LOGGING).edit().putBoolean("influx_cell_data", parseBoolean(payload)).apply();
             return;
         }
         if(topic.contains("/content/neighbour_cells")){
             Log.d(TAG, "handleConfigMessage: Neighbour Cells: " + payload);
-            spg.getSharedPreference(SPType.logging_sp).edit().putBoolean("log_neighbour_cells", parseBoolean(payload)).apply();
+            spg.getSharedPreference(SPType.LOGGING).edit().putBoolean("log_neighbour_cells", parseBoolean(payload)).apply();
             return;
         }
         if(topic.contains("/content/throughput_information")){
             Log.d(TAG, "handleConfigMessage: Throughput Information: " + payload);
-            spg.getSharedPreference(SPType.logging_sp).edit().putBoolean("influx_throughput_data", parseBoolean(payload)).apply();
+            spg.getSharedPreference(SPType.LOGGING).edit().putBoolean("influx_throughput_data", parseBoolean(payload)).apply();
             return;
         }
         if(topic.contains("/content/wifi_information")){
             Log.d(TAG, "handleConfigMessage: Wifi Information: " + payload);
-            spg.getSharedPreference(SPType.logging_sp).edit().putBoolean("log_wifi_data", parseBoolean(payload)).apply();
+            spg.getSharedPreference(SPType.LOGGING).edit().putBoolean("log_wifi_data", parseBoolean(payload)).apply();
             return;
         }
         if(topic.contains("/content/battery_information")){
             Log.d(TAG, "handleConfigMessage: Battery Information: " + payload);
-            spg.getSharedPreference(SPType.logging_sp).edit().putBoolean("influx_battery_data", parseBoolean(payload)).apply();
+            spg.getSharedPreference(SPType.LOGGING).edit().putBoolean("influx_battery_data", parseBoolean(payload)).apply();
             return;
         }
         if(topic.contains("/content/ip_information")){
             Log.d(TAG, "handleConfigMessage: IP Information: " + payload);
-            spg.getSharedPreference(SPType.logging_sp).edit().putBoolean("influx_ip_address_data", parseBoolean(payload)).apply();
+            spg.getSharedPreference(SPType.LOGGING).edit().putBoolean("influx_ip_address_data", parseBoolean(payload)).apply();
             return;
         }
 
@@ -445,14 +441,14 @@ public class MQTTService extends Service {
     public int onStartCommand(Intent intent, int flags, int startId) {
         Log.d(TAG, "onStartCommand: Start MQTT service");
         context = getApplicationContext();
-        mqttSP = SharedPreferencesGrouper.getInstance(context).getSharedPreference(SPType.mqtt_sp);
-        deviceName = SharedPreferencesGrouper.getInstance(context).getSharedPreference(SPType.default_sp).getString("device_name", "null").strip();
+        mqttSP = SharedPreferencesGrouper.getInstance(context).getSharedPreference(SPType.MQTT);
+        deviceName = SharedPreferencesGrouper.getInstance(context).getSharedPreference(SPType.MAIN).getString("device_name", "null").strip();
         startForeground(3, builder.build());
         setupSharedPreferences();
         createClient();
         if(client == null){
             Log.e(TAG, "onStartCommand: Client is null");
-            spg.getSharedPreference(SPType.mqtt_sp).edit().putBoolean("enable_mqtt", false).apply();
+            spg.getSharedPreference(SPType.MQTT).edit().putBoolean("enable_mqtt", false).apply();
             return START_NOT_STICKY;
         }
         connectClient();

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/MainActivity.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/MainActivity.java
@@ -91,7 +91,7 @@ public class MainActivity extends AppCompatActivity implements PreferenceFragmen
                     }
                 });
             }
-            requestCellInfoUpdateHandler.postDelayed(this, Integer.parseInt(spg.getSharedPreference(SPType.logging_sp).getString("logging_interval", "1000")));
+            requestCellInfoUpdateHandler.postDelayed(this, Integer.parseInt(spg.getSharedPreference(SPType.LOGGING).getString("logging_interval", "1000")));
         }
     };
     private Context context;
@@ -152,7 +152,7 @@ public class MainActivity extends AppCompatActivity implements PreferenceFragmen
                 // make sure the subscription in the app settings exists in the current subscription list.
                 // if it is not in the subscription list change it to the first one of the current list
                 boolean valid_subscription = false;
-                String pref_subscription_str = spg.getSharedPreference(SPType.default_sp).getString("select_subscription","99999");
+                String pref_subscription_str = spg.getSharedPreference(SPType.MAIN).getString("select_subscription","99999");
                 for (SubscriptionInfo info : dp.getSubscriptions()) {
                     if (Integer.parseInt(pref_subscription_str) == info.getSubscriptionId()) {
                         valid_subscription = true;
@@ -160,10 +160,10 @@ public class MainActivity extends AppCompatActivity implements PreferenceFragmen
                     }
                 }
                 if (!valid_subscription) {
-                    spg.getSharedPreference(SPType.default_sp).edit().putString("select_subscription", String.valueOf(dp.getSubscriptions().iterator().next().getSubscriptionId())).apply();
+                    spg.getSharedPreference(SPType.MAIN).edit().putString("select_subscription", String.valueOf(dp.getSubscriptions().iterator().next().getSubscriptionId())).apply();
                 }
                 // switch the telephony manager to a new one according to the app settings
-                tm = tm.createForSubscriptionId(Integer.parseInt(spg.getSharedPreference(SPType.default_sp).getString("select_subscription", "0")));
+                tm = tm.createForSubscriptionId(Integer.parseInt(spg.getSharedPreference(SPType.MAIN).getString("select_subscription", "0")));
 
                 // update reference to tm
                 gv.setTm(tm);
@@ -183,7 +183,7 @@ public class MainActivity extends AppCompatActivity implements PreferenceFragmen
         if (ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED) {
             LocationManager lm = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
             // if the location API on android is disabled and we don't want a fake location make a popup
-            if (!lm.isLocationEnabled() && !spg.getSharedPreference(SPType.logging_sp).getBoolean("fake_location", false)) {
+            if (!lm.isLocationEnabled() && !spg.getSharedPreference(SPType.LOGGING).getBoolean("fake_location", false)) {
                 new AlertDialog.Builder(MainActivity.this)
                         .setTitle(R.string.dialog_no_location_title)
                         .setMessage(R.string.dialog_no_location)
@@ -192,7 +192,7 @@ public class MainActivity extends AppCompatActivity implements PreferenceFragmen
                             intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                             getApplicationContext().startActivity(intent);
                         })
-                        .setNegativeButton(R.string.dialog_no_location_fake, (dialog, which) -> spg.getSharedPreference(SPType.logging_sp).edit().putBoolean("fake_location", true).apply())
+                        .setNegativeButton(R.string.dialog_no_location_fake, (dialog, which) -> spg.getSharedPreference(SPType.LOGGING).edit().putBoolean("fake_location", true).apply())
                         .setIcon(android.R.drawable.ic_dialog_map)
                         .show();
             }
@@ -201,7 +201,7 @@ public class MainActivity extends AppCompatActivity implements PreferenceFragmen
         initHandlerAndHandlerThread();
 
         loggingServiceIntent = new Intent(this, LoggingService.class);
-        if (spg.getSharedPreference(SPType.logging_sp).getBoolean("enable_logging", false)) {
+        if (spg.getSharedPreference(SPType.LOGGING).getBoolean("enable_logging", false)) {
             Log.d(TAG, "Start logging service");
             context.startForegroundService(loggingServiceIntent);
         }
@@ -216,10 +216,10 @@ public class MainActivity extends AppCompatActivity implements PreferenceFragmen
                     context.stopService(loggingServiceIntent);
                 }
             }
-        }, SPType.logging_sp);
+        }, SPType.LOGGING);
 
         notificationServiceIntent = new Intent(context, NotificationService.class);
-        if(spg.getSharedPreference(SPType.default_sp).getBoolean("enable_radio_notification", false)){
+        if(spg.getSharedPreference(SPType.MAIN).getBoolean("enable_radio_notification", false)){
             context.startService(notificationServiceIntent);
         }
         spg.setListener((prefs, key) -> {
@@ -230,10 +230,10 @@ public class MainActivity extends AppCompatActivity implements PreferenceFragmen
                     context.stopService(notificationServiceIntent);
                 }
             }
-        }, SPType.default_sp);
+        }, SPType.MAIN);
 
         mqttServiceIntent = new Intent(this, MQTTService.class);
-        if (spg.getSharedPreference(SPType.mqtt_sp).getBoolean("enable_mqtt", false)) {
+        if (spg.getSharedPreference(SPType.MQTT).getBoolean("enable_mqtt", false)) {
             Log.d(TAG, "Start MQTT service");
             context.startService(mqttServiceIntent);
         }
@@ -248,19 +248,19 @@ public class MainActivity extends AppCompatActivity implements PreferenceFragmen
                     context.stopService(mqttServiceIntent);
                 }
             }
-        }, SPType.mqtt_sp);
+        }, SPType.MQTT);
 
         Intent intent = getIntent();
         if (Intent.ACTION_VIEW.equals(intent.getAction())) {
             String mqtt_broker_address = intent.getStringExtra("mqtt_broker_address");
             String device_name = intent.getStringExtra("device_name");
             if(device_name != null){
-                spg.getSharedPreference(SPType.default_sp).edit()
+                spg.getSharedPreference(SPType.MAIN).edit()
                         .putString("device_name", device_name)
                         .apply();
             }
             if(mqtt_broker_address != null){
-                spg.getSharedPreference(SPType.mqtt_sp).edit()
+                spg.getSharedPreference(SPType.MQTT).edit()
                         .putBoolean("enable_mqtt", true)
                         .putString("mqtt_host", mqtt_broker_address)
                         .apply();

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/NotificationService.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/NotificationService.java
@@ -19,12 +19,9 @@ import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.IBinder;
 import android.util.Log;
-import android.widget.Toast;
 
 import androidx.annotation.Nullable;
 import androidx.core.app.NotificationCompat;
-
-import com.influxdb.client.domain.Run;
 
 import java.util.Objects;
 
@@ -91,7 +88,7 @@ public class NotificationService extends Service {
                 stopNotificationUpdate();
             }
 
-        }, SPType.default_sp);
+        }, SPType.MAIN);
         setupNotification();
         startForeground(4, builder.build());
 

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/OpenMobileNetworkToolkit.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/OpenMobileNetworkToolkit.java
@@ -50,41 +50,41 @@ public class OpenMobileNetworkToolkit extends CarrierService {
         Log.d(TAG, "applying carrier config");
         // API 27
         if (sdk_version >= Build.VERSION_CODES.O_MR1) {
-            configForSubId.putBoolean(CarrierConfigManager.KEY_DISPLAY_HD_AUDIO_PROPERTY_BOOL, spg.getSharedPreference(SPType.carrier_sp).getBoolean("switch_KEY_DISPLAY_HD_AUDIO_PROPERTY_BOOL",false));
+            configForSubId.putBoolean(CarrierConfigManager.KEY_DISPLAY_HD_AUDIO_PROPERTY_BOOL, spg.getSharedPreference(SPType.MOBILE_NETWORK).getBoolean("switch_KEY_DISPLAY_HD_AUDIO_PROPERTY_BOOL",false));
         }
 
         // API 30
         if (sdk_version >= Build.VERSION_CODES.R) {
-            configForSubId.putBoolean(CarrierConfigManager.KEY_ALLOW_VIDEO_CALLING_FALLBACK_BOOL, spg.getSharedPreference(SPType.carrier_sp).getBoolean("switch_KEY_ALLOW_VIDEO_CALLING_FALLBACK_BOOL", true));
-            configForSubId.putBoolean(CarrierConfigManager.KEY_CARRIER_DEFAULT_WFC_IMS_ENABLED_BOOL, spg.getSharedPreference(SPType.carrier_sp).getBoolean("switch_KEY_CARRIER_DEFAULT_WFC_IMS_ENABLED_BOOL", false));
-            configForSubId.putBoolean(CarrierConfigManager.KEY_HIDE_LTE_PLUS_DATA_ICON_BOOL, spg.getSharedPreference(SPType.carrier_sp).getBoolean("switch_KEY_HIDE_LTE_PLUS_DATA_ICON_BOOL", false));
-            configForSubId.putBoolean(CarrierConfigManager.KEY_WORLD_MODE_ENABLED_BOOL, spg.getSharedPreference(SPType.carrier_sp).getBoolean("switch_KEY_WORLD_MODE_ENABLED_BOOL", true));
-            configForSubId.putBoolean(CarrierConfigManager.KEY_CARRIER_RCS_PROVISIONING_REQUIRED_BOOL, spg.getSharedPreference(SPType.carrier_sp).getBoolean("switch_KEY_CARRIER_RCS_PROVISIONING_REQUIRED_BOOL", false));
-            configForSubId.putBoolean(CarrierConfigManager.KEY_SHOW_IMS_REGISTRATION_STATUS_BOOL, spg.getSharedPreference(SPType.carrier_sp).getBoolean("switch_KEY_SHOW_IMS_REGISTRATION_STATUS_BOOL", true));
-            configForSubId.putBoolean(CarrierConfigManager.KEY_EDITABLE_WFC_MODE_BOOL, spg.getSharedPreference(SPType.carrier_sp).getBoolean("switch_KEY_EDITABLE_WFC_MODE_BOOL", true));
-            configForSubId.putBoolean(CarrierConfigManager.KEY_EDITABLE_WFC_ROAMING_MODE_BOOL, spg.getSharedPreference(SPType.carrier_sp).getBoolean("switch_KEY_EDITABLE_WFC_ROAMING_MODE_BOOL", true));
-            configForSubId.putBoolean(CarrierConfigManager.KEY_CARRIER_DEFAULT_WFC_IMS_ENABLED_BOOL, spg.getSharedPreference(SPType.carrier_sp).getBoolean("switch_KEY_CARRIER_DEFAULT_WFC_IMS_ENABLED_BOOL", false));
-            configForSubId.putBoolean(CarrierConfigManager.KEY_CARRIER_VOLTE_OVERRIDE_WFC_PROVISIONING_BOOL, spg.getSharedPreference(SPType.carrier_sp).getBoolean("switch_KEY_CARRIER_DEFAULT_WFC_IMS_ENABLED_BOOL", false));
-            configForSubId.putStringArray(CarrierConfigManager.KEY_READ_ONLY_APN_FIELDS_STRING_ARRAY, new String[] {spg.getSharedPreference(SPType.carrier_sp).getString("edit_text_KEY_READ_ONLY_APN_FIELDS_STRING_ARRAY", "")});
-            configForSubId.putStringArray(CarrierConfigManager.KEY_APN_SETTINGS_DEFAULT_APN_TYPES_STRING_ARRAY, new String[] {spg.getSharedPreference(SPType.carrier_sp).getString("edit_text_KEY_APN_SETTINGS_DEFAULT_APN_TYPES_STRING_ARRAY", "")});
-            configForSubId.putBoolean(CarrierConfigManager.KEY_CARRIER_ALLOW_DEFLECT_IMS_CALL_BOOL, spg.getSharedPreference(SPType.carrier_sp).getBoolean("switch_KEY_CARRIER_ALLOW_DEFLECT_IMS_CALL_BOOL", true));
+            configForSubId.putBoolean(CarrierConfigManager.KEY_ALLOW_VIDEO_CALLING_FALLBACK_BOOL, spg.getSharedPreference(SPType.MOBILE_NETWORK).getBoolean("switch_KEY_ALLOW_VIDEO_CALLING_FALLBACK_BOOL", true));
+            configForSubId.putBoolean(CarrierConfigManager.KEY_CARRIER_DEFAULT_WFC_IMS_ENABLED_BOOL, spg.getSharedPreference(SPType.MOBILE_NETWORK).getBoolean("switch_KEY_CARRIER_DEFAULT_WFC_IMS_ENABLED_BOOL", false));
+            configForSubId.putBoolean(CarrierConfigManager.KEY_HIDE_LTE_PLUS_DATA_ICON_BOOL, spg.getSharedPreference(SPType.MOBILE_NETWORK).getBoolean("switch_KEY_HIDE_LTE_PLUS_DATA_ICON_BOOL", false));
+            configForSubId.putBoolean(CarrierConfigManager.KEY_WORLD_MODE_ENABLED_BOOL, spg.getSharedPreference(SPType.MOBILE_NETWORK).getBoolean("switch_KEY_WORLD_MODE_ENABLED_BOOL", true));
+            configForSubId.putBoolean(CarrierConfigManager.KEY_CARRIER_RCS_PROVISIONING_REQUIRED_BOOL, spg.getSharedPreference(SPType.MOBILE_NETWORK).getBoolean("switch_KEY_CARRIER_RCS_PROVISIONING_REQUIRED_BOOL", false));
+            configForSubId.putBoolean(CarrierConfigManager.KEY_SHOW_IMS_REGISTRATION_STATUS_BOOL, spg.getSharedPreference(SPType.MOBILE_NETWORK).getBoolean("switch_KEY_SHOW_IMS_REGISTRATION_STATUS_BOOL", true));
+            configForSubId.putBoolean(CarrierConfigManager.KEY_EDITABLE_WFC_MODE_BOOL, spg.getSharedPreference(SPType.MOBILE_NETWORK).getBoolean("switch_KEY_EDITABLE_WFC_MODE_BOOL", true));
+            configForSubId.putBoolean(CarrierConfigManager.KEY_EDITABLE_WFC_ROAMING_MODE_BOOL, spg.getSharedPreference(SPType.MOBILE_NETWORK).getBoolean("switch_KEY_EDITABLE_WFC_ROAMING_MODE_BOOL", true));
+            configForSubId.putBoolean(CarrierConfigManager.KEY_CARRIER_DEFAULT_WFC_IMS_ENABLED_BOOL, spg.getSharedPreference(SPType.MOBILE_NETWORK).getBoolean("switch_KEY_CARRIER_DEFAULT_WFC_IMS_ENABLED_BOOL", false));
+            configForSubId.putBoolean(CarrierConfigManager.KEY_CARRIER_VOLTE_OVERRIDE_WFC_PROVISIONING_BOOL, spg.getSharedPreference(SPType.MOBILE_NETWORK).getBoolean("switch_KEY_CARRIER_DEFAULT_WFC_IMS_ENABLED_BOOL", false));
+            configForSubId.putStringArray(CarrierConfigManager.KEY_READ_ONLY_APN_FIELDS_STRING_ARRAY, new String[] {spg.getSharedPreference(SPType.MOBILE_NETWORK).getString("edit_text_KEY_READ_ONLY_APN_FIELDS_STRING_ARRAY", "")});
+            configForSubId.putStringArray(CarrierConfigManager.KEY_APN_SETTINGS_DEFAULT_APN_TYPES_STRING_ARRAY, new String[] {spg.getSharedPreference(SPType.MOBILE_NETWORK).getString("edit_text_KEY_APN_SETTINGS_DEFAULT_APN_TYPES_STRING_ARRAY", "")});
+            configForSubId.putBoolean(CarrierConfigManager.KEY_CARRIER_ALLOW_DEFLECT_IMS_CALL_BOOL, spg.getSharedPreference(SPType.MOBILE_NETWORK).getBoolean("switch_KEY_CARRIER_ALLOW_DEFLECT_IMS_CALL_BOOL", true));
         }
 
         // API 31
         if (sdk_version >= Build.VERSION_CODES.S) {
             int[] nr_av = new int[2];
             int i = 0;
-            for (String value: spg.getSharedPreference(SPType.carrier_sp).getStringSet("multi_select_KEY_CARRIER_NR_AVAILABILITIES_INT_ARRAY", new HashSet<>(Arrays.asList("1", "2")))){
+            for (String value: spg.getSharedPreference(SPType.MOBILE_NETWORK).getStringSet("multi_select_KEY_CARRIER_NR_AVAILABILITIES_INT_ARRAY", new HashSet<>(Arrays.asList("1", "2")))){
                 nr_av[i] = Integer.parseInt(value);
             }
             configForSubId.putIntArray(CarrierConfigManager.KEY_CARRIER_NR_AVAILABILITIES_INT_ARRAY, nr_av);
-            configForSubId.putBoolean(CarrierConfigManager.KEY_HIDE_TTY_HCO_VCO_WITH_RTT_BOOL, spg.getSharedPreference(SPType.carrier_sp).getBoolean("switch_KEY_HIDE_TTY_HCO_VCO_WITH_RTT_BOOL", false));
-            //configForSubId.putBoolean(CarrierConfigManager.KEY_HIDE_ENABLE_2G, spg.getSharedPreference(SPType.carrier_sp).getBoolean("switch_KEY_HIDE_ENABLE_2G", false));
-            configForSubId.putBoolean(CarrierConfigManager.KEY_RTT_UPGRADE_SUPPORTED_FOR_DOWNGRADED_VT_CALL_BOOL, spg.getSharedPreference(SPType.carrier_sp).getBoolean("switch_KEY_RTT_UPGRADE_SUPPORTED_FOR_DOWNGRADED_VT_CALL_BOOL", true));
+            configForSubId.putBoolean(CarrierConfigManager.KEY_HIDE_TTY_HCO_VCO_WITH_RTT_BOOL, spg.getSharedPreference(SPType.MOBILE_NETWORK).getBoolean("switch_KEY_HIDE_TTY_HCO_VCO_WITH_RTT_BOOL", false));
+            //configForSubId.putBoolean(CarrierConfigManager.KEY_HIDE_ENABLE_2G, spg.getSharedPreference(SPType.MOBILE_NETWORK).getBoolean("switch_KEY_HIDE_ENABLE_2G", false));
+            configForSubId.putBoolean(CarrierConfigManager.KEY_RTT_UPGRADE_SUPPORTED_FOR_DOWNGRADED_VT_CALL_BOOL, spg.getSharedPreference(SPType.MOBILE_NETWORK).getBoolean("switch_KEY_RTT_UPGRADE_SUPPORTED_FOR_DOWNGRADED_VT_CALL_BOOL", true));
 
             // VoLTE
             // check if a VoLTE / VoNR EPDG address is configured and apply it.
-            String epdg = spg.getSharedPreference(SPType.carrier_sp).getString("edit_text_EPDG_STATIC_ADDRESS", "");
+            String epdg = spg.getSharedPreference(SPType.MOBILE_NETWORK).getString("edit_text_EPDG_STATIC_ADDRESS", "");
             if (!epdg.isEmpty()) {
                 configForSubId.putString(CarrierConfigManager.Iwlan.KEY_EPDG_STATIC_ADDRESS_STRING, epdg);
                 configForSubId.putString(CarrierConfigManager.Iwlan.KEY_EPDG_STATIC_ADDRESS_ROAMING_STRING, epdg);
@@ -93,41 +93,41 @@ public class OpenMobileNetworkToolkit extends CarrierService {
         }
 
         // API <= 29
-        configForSubId.putBoolean(CarrierConfigManager.KEY_FORCE_HOME_NETWORK_BOOL, spg.getSharedPreference(SPType.carrier_sp).getBoolean("switch_KEY_FORCE_HOME_NETWORK_BOOL", false));
-        configForSubId.putBoolean(CarrierConfigManager.KEY_PREFER_2G_BOOL, spg.getSharedPreference(SPType.carrier_sp).getBoolean("switch_KEY_PREFER_2G_BOOL", false));
-        configForSubId.putBoolean(CarrierConfigManager.KEY_CARRIER_SETTINGS_ENABLE_BOOL, spg.getSharedPreference(SPType.carrier_sp).getBoolean("switch_KEY_CARRIER_SETTINGS_ENABLE_BOOL", true));
-        configForSubId.putBoolean(CarrierConfigManager.KEY_CARRIER_ALLOW_TURNOFF_IMS_BOOL, spg.getSharedPreference(SPType.carrier_sp).getBoolean("switch_KEY_CARRIER_ALLOW_TURNOFF_IMS_BOOL", true));
-        configForSubId.putBoolean(CarrierConfigManager.KEY_CARRIER_WFC_IMS_AVAILABLE_BOOL, spg.getSharedPreference(SPType.carrier_sp).getBoolean("switch_KEY_CARRIER_WFC_IMS_AVAILABLE_BOOL", true));
-        configForSubId.putBoolean(CarrierConfigManager.KEY_EDITABLE_ENHANCED_4G_LTE_BOOL, spg.getSharedPreference(SPType.carrier_sp).getBoolean("switch_KEY_EDITABLE_ENHANCED_4G_LTE_BOOL", true));
-        configForSubId.putBoolean(CarrierConfigManager.KEY_CARRIER_VOLTE_AVAILABLE_BOOL, spg.getSharedPreference(SPType.carrier_sp).getBoolean("switch_KEY_CARRIER_VOLTE_AVAILABLE_BOOL", true));
-        configForSubId.putBoolean(CarrierConfigManager.KEY_CARRIER_VOLTE_PROVISIONING_REQUIRED_BOOL, spg.getSharedPreference(SPType.carrier_sp).getBoolean("switch_KEY_CARRIER_VOLTE_PROVISIONING_REQUIRED_BOOL", false));
-        configForSubId.putBoolean(CarrierConfigManager.KEY_CARRIER_VOLTE_PROVISIONED_BOOL, spg.getSharedPreference(SPType.carrier_sp).getBoolean("switch_KEY_CARRIER_VOLTE_PROVISIONED_BOOL", false));
-        configForSubId.putBoolean(CarrierConfigManager.KEY_CARRIER_VT_AVAILABLE_BOOL, spg.getSharedPreference(SPType.carrier_sp).getBoolean("switch_KEY_CARRIER_VT_AVAILABLE_BOOL", false));
-        configForSubId.putBoolean(CarrierConfigManager.KEY_CARRIER_VOLTE_TTY_SUPPORTED_BOOL, spg.getSharedPreference(SPType.carrier_sp).getBoolean("switch_KEY_CARRIER_VOLTE_TTY_SUPPORTED_BOOL", false));
-        configForSubId.putBoolean(CarrierConfigManager.KEY_HIDE_ENHANCED_4G_LTE_BOOL, spg.getSharedPreference(SPType.carrier_sp).getBoolean("switch_KEY_HIDE_ENHANCED_4G_LTE_BOOL", false));
-        configForSubId.putBoolean(CarrierConfigManager.KEY_HIDE_CARRIER_NETWORK_SETTINGS_BOOL, spg.getSharedPreference(SPType.carrier_sp).getBoolean("switch_KEY_HIDE_CARRIER_NETWORK_SETTINGS_BOOL", false));
-        configForSubId.putBoolean(CarrierConfigManager.KEY_HIDE_IMS_APN_BOOL, spg.getSharedPreference(SPType.carrier_sp).getBoolean("switch_KEY_HIDE_IMS_APN_BOOL", false));
-        configForSubId.putBoolean(CarrierConfigManager.KEY_HIDE_PREFERRED_NETWORK_TYPE_BOOL, spg.getSharedPreference(SPType.carrier_sp).getBoolean("switch_KEY_HIDE_PREFERRED_NETWORK_TYPE_BOOL", false));
-        configForSubId.putBoolean(CarrierConfigManager.KEY_HIDE_PRESET_APN_DETAILS_BOOL, spg.getSharedPreference(SPType.carrier_sp).getBoolean("switch_KEY_HIDE_PRESET_APN_DETAILS_BOOL", false));
-        configForSubId.putBoolean(CarrierConfigManager.KEY_HIDE_SIM_LOCK_SETTINGS_BOOL, spg.getSharedPreference(SPType.carrier_sp).getBoolean("switch_KEY_HIDE_SIM_LOCK_SETTINGS_BOOL", false));
-        configForSubId.putBoolean(CarrierConfigManager.KEY_ALLOW_ADDING_APNS_BOOL, spg.getSharedPreference(SPType.carrier_sp).getBoolean("switch_KEY_ALLOW_ADDING_APNS_BOOL", true));
-        configForSubId.putBoolean(CarrierConfigManager.KEY_APN_EXPAND_BOOL, spg.getSharedPreference(SPType.carrier_sp).getBoolean("switch_KEY_APN_EXPAND_BOOL",true));
-        configForSubId.putBoolean(CarrierConfigManager.KEY_CARRIER_WFC_SUPPORTS_WIFI_ONLY_BOOL, spg.getSharedPreference(SPType.carrier_sp).getBoolean("switch_KEY_CARRIER_WFC_SUPPORTS_WIFI_ONLY_BOOL", false));
-        configForSubId.putBoolean(CarrierConfigManager.KEY_CARRIER_IMS_GBA_REQUIRED_BOOL, spg.getSharedPreference(SPType.carrier_sp).getBoolean("switch_KEY_CARRIER_IMS_GBA_REQUIRED_BOOL", false));
-        configForSubId.putBoolean(CarrierConfigManager.KEY_REQUIRE_ENTITLEMENT_CHECKS_BOOL, spg.getSharedPreference(SPType.carrier_sp).getBoolean("switch_KEY_REQUIRE_ENTITLEMENT_CHECKS_BOOL", false));
-        configForSubId.putInt(CarrierConfigManager.KEY_VOLTE_REPLACEMENT_RAT_INT, Integer.parseInt(spg.getSharedPreference(SPType.carrier_sp).getString("list_KEY_VOLTE_REPLACEMENT_RAT_INT9","18")));
-        configForSubId.putBoolean(CarrierConfigManager.KEY_CARRIER_USE_IMS_FIRST_FOR_EMERGENCY_BOOL, spg.getSharedPreference(SPType.carrier_sp).getBoolean("switch_KEY_CARRIER_USE_IMS_FIRST_FOR_EMERGENCY_BOOL",false));
-        configForSubId.putBoolean(CarrierConfigManager.KEY_AUTO_RETRY_ENABLED_BOOL, spg.getSharedPreference(SPType.carrier_sp).getBoolean("switch_KEY_AUTO_RETRY_ENABLED_BOOL", false));
-        configForSubId.putBoolean(CarrierConfigManager.KEY_WORLD_PHONE_BOOL, spg.getSharedPreference(SPType.carrier_sp).getBoolean("switch_KEY_WORLD_PHONE_BOOL",true));
-        configForSubId.putBoolean(CarrierConfigManager.KEY_IS_IMS_CONFERENCE_SIZE_ENFORCED_BOOL, spg.getSharedPreference(SPType.carrier_sp).getBoolean("switch_KEY_SUPPORT_PAUSE_IMS_VIDEO_CALLS_BOOL", false));
-        configForSubId.putBoolean(CarrierConfigManager.KEY_SUPPORT_PAUSE_IMS_VIDEO_CALLS_BOOL, spg.getSharedPreference(SPType.carrier_sp).getBoolean("switch_KEY_CARRIER_UT_PROVISIONING_REQUIRED_BOOL", false));
-        configForSubId.putBoolean(CarrierConfigManager.KEY_CARRIER_UT_PROVISIONING_REQUIRED_BOOL, spg.getSharedPreference(SPType.carrier_sp).getBoolean("switch_KEY_CARRIER_SUPPORTS_SS_OVER_UT_BOOL", false));
-        configForSubId.putBoolean(CarrierConfigManager.KEY_CARRIER_SUPPORTS_SS_OVER_UT_BOOL, spg.getSharedPreference(SPType.carrier_sp).getBoolean("switch_KEY_ENHANCED_4G_LTE_ON_BY_DEFAULT_BOOL", false));
-        configForSubId.putBoolean(CarrierConfigManager.KEY_ENHANCED_4G_LTE_ON_BY_DEFAULT_BOOL, spg.getSharedPreference(SPType.carrier_sp).getBoolean("switch_KEY_SUPPORT_EMERGENCY_SMS_OVER_IMS_BOOL", false));
-        configForSubId.putBoolean(CarrierConfigManager.KEY_SUPPORT_EMERGENCY_SMS_OVER_IMS_BOOL, spg.getSharedPreference(SPType.carrier_sp).getBoolean("switch_KEY_CARRIER_DEFAULT_WFC_IMS_MODE_INT", false));
-        configForSubId.putInt(CarrierConfigManager.KEY_CARRIER_DEFAULT_WFC_IMS_MODE_INT, Integer.parseInt(spg.getSharedPreference(SPType.carrier_sp).getString("list_KEY_CARRIER_DEFAULT_WFC_IMS_MODE_INT", "1")));
-        configForSubId.putInt(CarrierConfigManager.KEY_CARRIER_DEFAULT_WFC_IMS_ROAMING_MODE_INT, Integer.parseInt(spg.getSharedPreference(SPType.carrier_sp).getString("list_KEY_CARRIER_DEFAULT_WFC_IMS_ROAMING_MODE_INT","1")));
-        configForSubId.putBoolean(CarrierConfigManager.KEY_ALLOW_EMERGENCY_VIDEO_CALLS_BOOL, spg.getSharedPreference(SPType.carrier_sp).getBoolean("switch_KEY_ALLOW_EMERGENCY_VIDEO_CALLS_BOOL",false));
+        configForSubId.putBoolean(CarrierConfigManager.KEY_FORCE_HOME_NETWORK_BOOL, spg.getSharedPreference(SPType.MOBILE_NETWORK).getBoolean("switch_KEY_FORCE_HOME_NETWORK_BOOL", false));
+        configForSubId.putBoolean(CarrierConfigManager.KEY_PREFER_2G_BOOL, spg.getSharedPreference(SPType.MOBILE_NETWORK).getBoolean("switch_KEY_PREFER_2G_BOOL", false));
+        configForSubId.putBoolean(CarrierConfigManager.KEY_CARRIER_SETTINGS_ENABLE_BOOL, spg.getSharedPreference(SPType.MOBILE_NETWORK).getBoolean("switch_KEY_CARRIER_SETTINGS_ENABLE_BOOL", true));
+        configForSubId.putBoolean(CarrierConfigManager.KEY_CARRIER_ALLOW_TURNOFF_IMS_BOOL, spg.getSharedPreference(SPType.MOBILE_NETWORK).getBoolean("switch_KEY_CARRIER_ALLOW_TURNOFF_IMS_BOOL", true));
+        configForSubId.putBoolean(CarrierConfigManager.KEY_CARRIER_WFC_IMS_AVAILABLE_BOOL, spg.getSharedPreference(SPType.MOBILE_NETWORK).getBoolean("switch_KEY_CARRIER_WFC_IMS_AVAILABLE_BOOL", true));
+        configForSubId.putBoolean(CarrierConfigManager.KEY_EDITABLE_ENHANCED_4G_LTE_BOOL, spg.getSharedPreference(SPType.MOBILE_NETWORK).getBoolean("switch_KEY_EDITABLE_ENHANCED_4G_LTE_BOOL", true));
+        configForSubId.putBoolean(CarrierConfigManager.KEY_CARRIER_VOLTE_AVAILABLE_BOOL, spg.getSharedPreference(SPType.MOBILE_NETWORK).getBoolean("switch_KEY_CARRIER_VOLTE_AVAILABLE_BOOL", true));
+        configForSubId.putBoolean(CarrierConfigManager.KEY_CARRIER_VOLTE_PROVISIONING_REQUIRED_BOOL, spg.getSharedPreference(SPType.MOBILE_NETWORK).getBoolean("switch_KEY_CARRIER_VOLTE_PROVISIONING_REQUIRED_BOOL", false));
+        configForSubId.putBoolean(CarrierConfigManager.KEY_CARRIER_VOLTE_PROVISIONED_BOOL, spg.getSharedPreference(SPType.MOBILE_NETWORK).getBoolean("switch_KEY_CARRIER_VOLTE_PROVISIONED_BOOL", false));
+        configForSubId.putBoolean(CarrierConfigManager.KEY_CARRIER_VT_AVAILABLE_BOOL, spg.getSharedPreference(SPType.MOBILE_NETWORK).getBoolean("switch_KEY_CARRIER_VT_AVAILABLE_BOOL", false));
+        configForSubId.putBoolean(CarrierConfigManager.KEY_CARRIER_VOLTE_TTY_SUPPORTED_BOOL, spg.getSharedPreference(SPType.MOBILE_NETWORK).getBoolean("switch_KEY_CARRIER_VOLTE_TTY_SUPPORTED_BOOL", false));
+        configForSubId.putBoolean(CarrierConfigManager.KEY_HIDE_ENHANCED_4G_LTE_BOOL, spg.getSharedPreference(SPType.MOBILE_NETWORK).getBoolean("switch_KEY_HIDE_ENHANCED_4G_LTE_BOOL", false));
+        configForSubId.putBoolean(CarrierConfigManager.KEY_HIDE_CARRIER_NETWORK_SETTINGS_BOOL, spg.getSharedPreference(SPType.MOBILE_NETWORK).getBoolean("switch_KEY_HIDE_CARRIER_NETWORK_SETTINGS_BOOL", false));
+        configForSubId.putBoolean(CarrierConfigManager.KEY_HIDE_IMS_APN_BOOL, spg.getSharedPreference(SPType.MOBILE_NETWORK).getBoolean("switch_KEY_HIDE_IMS_APN_BOOL", false));
+        configForSubId.putBoolean(CarrierConfigManager.KEY_HIDE_PREFERRED_NETWORK_TYPE_BOOL, spg.getSharedPreference(SPType.MOBILE_NETWORK).getBoolean("switch_KEY_HIDE_PREFERRED_NETWORK_TYPE_BOOL", false));
+        configForSubId.putBoolean(CarrierConfigManager.KEY_HIDE_PRESET_APN_DETAILS_BOOL, spg.getSharedPreference(SPType.MOBILE_NETWORK).getBoolean("switch_KEY_HIDE_PRESET_APN_DETAILS_BOOL", false));
+        configForSubId.putBoolean(CarrierConfigManager.KEY_HIDE_SIM_LOCK_SETTINGS_BOOL, spg.getSharedPreference(SPType.MOBILE_NETWORK).getBoolean("switch_KEY_HIDE_SIM_LOCK_SETTINGS_BOOL", false));
+        configForSubId.putBoolean(CarrierConfigManager.KEY_ALLOW_ADDING_APNS_BOOL, spg.getSharedPreference(SPType.MOBILE_NETWORK).getBoolean("switch_KEY_ALLOW_ADDING_APNS_BOOL", true));
+        configForSubId.putBoolean(CarrierConfigManager.KEY_APN_EXPAND_BOOL, spg.getSharedPreference(SPType.MOBILE_NETWORK).getBoolean("switch_KEY_APN_EXPAND_BOOL",true));
+        configForSubId.putBoolean(CarrierConfigManager.KEY_CARRIER_WFC_SUPPORTS_WIFI_ONLY_BOOL, spg.getSharedPreference(SPType.MOBILE_NETWORK).getBoolean("switch_KEY_CARRIER_WFC_SUPPORTS_WIFI_ONLY_BOOL", false));
+        configForSubId.putBoolean(CarrierConfigManager.KEY_CARRIER_IMS_GBA_REQUIRED_BOOL, spg.getSharedPreference(SPType.MOBILE_NETWORK).getBoolean("switch_KEY_CARRIER_IMS_GBA_REQUIRED_BOOL", false));
+        configForSubId.putBoolean(CarrierConfigManager.KEY_REQUIRE_ENTITLEMENT_CHECKS_BOOL, spg.getSharedPreference(SPType.MOBILE_NETWORK).getBoolean("switch_KEY_REQUIRE_ENTITLEMENT_CHECKS_BOOL", false));
+        configForSubId.putInt(CarrierConfigManager.KEY_VOLTE_REPLACEMENT_RAT_INT, Integer.parseInt(spg.getSharedPreference(SPType.MOBILE_NETWORK).getString("list_KEY_VOLTE_REPLACEMENT_RAT_INT9","18")));
+        configForSubId.putBoolean(CarrierConfigManager.KEY_CARRIER_USE_IMS_FIRST_FOR_EMERGENCY_BOOL, spg.getSharedPreference(SPType.MOBILE_NETWORK).getBoolean("switch_KEY_CARRIER_USE_IMS_FIRST_FOR_EMERGENCY_BOOL",false));
+        configForSubId.putBoolean(CarrierConfigManager.KEY_AUTO_RETRY_ENABLED_BOOL, spg.getSharedPreference(SPType.MOBILE_NETWORK).getBoolean("switch_KEY_AUTO_RETRY_ENABLED_BOOL", false));
+        configForSubId.putBoolean(CarrierConfigManager.KEY_WORLD_PHONE_BOOL, spg.getSharedPreference(SPType.MOBILE_NETWORK).getBoolean("switch_KEY_WORLD_PHONE_BOOL",true));
+        configForSubId.putBoolean(CarrierConfigManager.KEY_IS_IMS_CONFERENCE_SIZE_ENFORCED_BOOL, spg.getSharedPreference(SPType.MOBILE_NETWORK).getBoolean("switch_KEY_SUPPORT_PAUSE_IMS_VIDEO_CALLS_BOOL", false));
+        configForSubId.putBoolean(CarrierConfigManager.KEY_SUPPORT_PAUSE_IMS_VIDEO_CALLS_BOOL, spg.getSharedPreference(SPType.MOBILE_NETWORK).getBoolean("switch_KEY_CARRIER_UT_PROVISIONING_REQUIRED_BOOL", false));
+        configForSubId.putBoolean(CarrierConfigManager.KEY_CARRIER_UT_PROVISIONING_REQUIRED_BOOL, spg.getSharedPreference(SPType.MOBILE_NETWORK).getBoolean("switch_KEY_CARRIER_SUPPORTS_SS_OVER_UT_BOOL", false));
+        configForSubId.putBoolean(CarrierConfigManager.KEY_CARRIER_SUPPORTS_SS_OVER_UT_BOOL, spg.getSharedPreference(SPType.MOBILE_NETWORK).getBoolean("switch_KEY_ENHANCED_4G_LTE_ON_BY_DEFAULT_BOOL", false));
+        configForSubId.putBoolean(CarrierConfigManager.KEY_ENHANCED_4G_LTE_ON_BY_DEFAULT_BOOL, spg.getSharedPreference(SPType.MOBILE_NETWORK).getBoolean("switch_KEY_SUPPORT_EMERGENCY_SMS_OVER_IMS_BOOL", false));
+        configForSubId.putBoolean(CarrierConfigManager.KEY_SUPPORT_EMERGENCY_SMS_OVER_IMS_BOOL, spg.getSharedPreference(SPType.MOBILE_NETWORK).getBoolean("switch_KEY_CARRIER_DEFAULT_WFC_IMS_MODE_INT", false));
+        configForSubId.putInt(CarrierConfigManager.KEY_CARRIER_DEFAULT_WFC_IMS_MODE_INT, Integer.parseInt(spg.getSharedPreference(SPType.MOBILE_NETWORK).getString("list_KEY_CARRIER_DEFAULT_WFC_IMS_MODE_INT", "1")));
+        configForSubId.putInt(CarrierConfigManager.KEY_CARRIER_DEFAULT_WFC_IMS_ROAMING_MODE_INT, Integer.parseInt(spg.getSharedPreference(SPType.MOBILE_NETWORK).getString("list_KEY_CARRIER_DEFAULT_WFC_IMS_ROAMING_MODE_INT","1")));
+        configForSubId.putBoolean(CarrierConfigManager.KEY_ALLOW_EMERGENCY_VIDEO_CALLS_BOOL, spg.getSharedPreference(SPType.MOBILE_NETWORK).getBoolean("switch_KEY_ALLOW_EMERGENCY_VIDEO_CALLS_BOOL",false));
         Log.d(TAG, "Carrier settings applied");
         return configForSubId;
     }

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Ping/PingFragment.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Ping/PingFragment.java
@@ -9,7 +9,6 @@
 package de.fraunhofer.fokus.OpenMobileNetworkToolkit.Ping;
 
 import static android.view.View.GONE;
-import static android.view.View.INVISIBLE;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
@@ -109,7 +108,7 @@ public class PingFragment extends Fragment {
 
             @Override
             public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
-                spg.getSharedPreference(SPType.ping_sp).edit().putString(name, field.getText().toString()).apply();
+                spg.getSharedPreference(SPType.PING).edit().putString(name, field.getText().toString()).apply();
             }
 
             @Override
@@ -176,7 +175,7 @@ public class PingFragment extends Fragment {
 
     }
     private void setupRepeatButton(){
-        boolean isRepeat = spg.getSharedPreference(SPType.ping_sp).getBoolean("repeat_ping", false);
+        boolean isRepeat = spg.getSharedPreference(SPType.PING).getBoolean("repeat_ping", false);
         int color = ContextCompat.getColor(ct,
                 isRepeat ? R.color.design_default_color_primary : R.color.material_dynamic_secondary40);
         repeatButton.setColorFilter(color);
@@ -186,8 +185,8 @@ public class PingFragment extends Fragment {
     public void onResume() {
         super.onResume();
         Log.d(TAG, "onResume: PingFragment resumed");
-        spg.getSharedPreference(SPType.ping_sp).registerOnSharedPreferenceChangeListener(listener);
-        checkLastUUID(spg.getSharedPreference(SPType.ping_sp).getString(PingService.PING_LAST_UUID, null));
+        spg.getSharedPreference(SPType.PING).registerOnSharedPreferenceChangeListener(listener);
+        checkLastUUID(spg.getSharedPreference(SPType.PING).getString(PingService.PING_LAST_UUID, null));
 
     }
 
@@ -195,7 +194,7 @@ public class PingFragment extends Fragment {
     public void onDestroy() {
         super.onDestroy();
         Log.d(TAG, "onDestroy: PingFragment destroyed");
-        spg.getSharedPreference(SPType.ping_sp).unregisterOnSharedPreferenceChangeListener(listener);
+        spg.getSharedPreference(SPType.PING).unregisterOnSharedPreferenceChangeListener(listener);
         workInfoLiveData.removeObserver(observer);
     }
 
@@ -213,9 +212,9 @@ public class PingFragment extends Fragment {
             }
         };
 
-        spg.getSharedPreference(SPType.ping_sp).registerOnSharedPreferenceChangeListener(listener);
+        spg.getSharedPreference(SPType.PING).registerOnSharedPreferenceChangeListener(listener);
 
-        checkLastUUID(spg.getSharedPreference(SPType.ping_sp).getString(PingService.PING_LAST_UUID, null));
+        checkLastUUID(spg.getSharedPreference(SPType.PING).getString(PingService.PING_LAST_UUID, null));
     }
 
     @SuppressLint("UnspecifiedRegisterReceiverFlag")
@@ -231,18 +230,18 @@ public class PingFragment extends Fragment {
         pingTextView = v.findViewById(R.id.ping_output);
         toggleGroup = verticalLL.findViewById(R.id.ping_toggle_group);
         input = verticalLL.findViewById(R.id.ping_input);
-        input.setText(spg.getSharedPreference(SPType.ping_sp).getString("ping_input", "-w 5 8.8.8.8"));
+        input.setText(spg.getSharedPreference(SPType.PING).getString("ping_input", "-w 5 8.8.8.8"));
         repeatButton = v.findViewById(R.id.ping_repeat_button);
         setupRepeatButton();
         repeatButton.setOnClickListener(view -> {
             Log.d(TAG, "onCreateView: Repeat button clicked");
-            boolean isRepeat = spg.getSharedPreference(SPType.ping_sp).getBoolean("repeat_ping", false);
-            spg.getSharedPreference(SPType.ping_sp).edit().putBoolean("repeat_ping", !isRepeat).apply();
+            boolean isRepeat = spg.getSharedPreference(SPType.PING).getBoolean("repeat_ping", false);
+            spg.getSharedPreference(SPType.PING).edit().putBoolean("repeat_ping", !isRepeat).apply();
             setupRepeatButton();
         });
 
         saveTextInputToSharedPreferences(input, "ping_input");
-        boolean pingRunning = spg.getSharedPreference(SPType.ping_sp).getBoolean("ping_running", false);
+        boolean pingRunning = spg.getSharedPreference(SPType.PING).getBoolean("ping_running", false);
         if (pingRunning) {
             v.findViewById(R.id.ping_start).setBackgroundColor(ct.getResources().getColor(R.color.purple_500, null));
         } else {
@@ -259,11 +258,11 @@ public class PingFragment extends Fragment {
                 } else {
                     v.findViewById(R.id.ping_start).setBackgroundColor(Color.TRANSPARENT);
                     v.findViewById(R.id.ping_stop).setBackgroundColor(ct.getResources().getColor(R.color.purple_500, null));
-                    spg.getSharedPreference(SPType.ping_sp).edit().putBoolean("ping_running", false).apply();
+                    spg.getSharedPreference(SPType.PING).edit().putBoolean("ping_running", false).apply();
                     toggleGroup.check(R.id.ping_stop);
                 }
             }
-        }, SPType.ping_sp);
+        }, SPType.PING);
         input.setEnabled(!pingRunning);
         toggleGroup.addOnButtonCheckedListener((group, checkedId, isChecked) -> {
             Log.d(TAG, "onButtonChecked: " + checkedId);
@@ -272,7 +271,7 @@ public class PingFragment extends Fragment {
                 case R.id.ping_start:
                     v.findViewById(R.id.ping_start).setBackgroundColor(ct.getResources().getColor(R.color.purple_500, null));
                     v.findViewById(R.id.ping_stop).setBackgroundColor(Color.TRANSPARENT);
-                    spg.getSharedPreference(SPType.ping_sp).edit().putBoolean("ping_running", true).apply();
+                    spg.getSharedPreference(SPType.PING).edit().putBoolean("ping_running", true).apply();
                     Intent startIntent = new Intent(ct, PingService.class);
                     startIntent.putExtra(PingService.PING_INTENT_COMMAND, input.getText().toString());
                     startIntent.putExtra(PingService.PING_INTENT_ENABLE, true);
@@ -283,7 +282,7 @@ public class PingFragment extends Fragment {
                 case R.id.ping_stop:
                     v.findViewById(R.id.ping_start).setBackgroundColor(Color.TRANSPARENT);
                     v.findViewById(R.id.ping_stop).setBackgroundColor(ct.getResources().getColor(R.color.purple_500, null));
-                    spg.getSharedPreference(SPType.ping_sp).edit().putBoolean("ping_running", false).apply();
+                    spg.getSharedPreference(SPType.PING).edit().putBoolean("ping_running", false).apply();
                     Intent stopIntent = new Intent(ct, PingService.class);
                     stopIntent.putExtra(PingService.PING_INTENT_ENABLE, false);
                     ct.startService(stopIntent);

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Ping/PingService.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Ping/PingService.java
@@ -49,7 +49,7 @@ public class PingService extends Service {
     @Override
     public void onDestroy() {
         Log.d(TAG, "onDestroy: Stop logging service");
-        spg.getSharedPreference(SPType.ping_sp).edit().putBoolean("ping_running", false).apply();
+        spg.getSharedPreference(SPType.PING).edit().putBoolean("ping_running", false).apply();
         stopWorker();
     }
 
@@ -74,10 +74,10 @@ public class PingService extends Service {
                 .addTag(PingToLineProtocolWorker.TAG)
                 .build();
 
-        spg.getSharedPreference(SPType.ping_sp).edit().putString(PING_LAST_UUID, pingWR.getId().toString()).apply();
+        spg.getSharedPreference(SPType.PING).edit().putString(PING_LAST_UUID, pingWR.getId().toString()).apply();
         registerObserver(command);
         WorkContinuation workContinuation = workManager.beginWith(pingWR).then(pingToLineProtocolWR);
-        if(spg.getSharedPreference(SPType.logging_sp).getBoolean("enable_influx", false)){
+        if(spg.getSharedPreference(SPType.LOGGING).getBoolean("enable_influx", false)){
             OneTimeWorkRequest influxDB2xUploadWorker = new OneTimeWorkRequest.Builder(InfluxDB2xUploadWorker.class)
                     .setInputData(data)
                     .addTag(uuid)
@@ -89,7 +89,7 @@ public class PingService extends Service {
 
     }
     private void stopWorker(){
-        String lastUUID = spg.getSharedPreference(SPType.ping_sp).getString(PING_LAST_UUID, "");
+        String lastUUID = spg.getSharedPreference(SPType.PING).getString(PING_LAST_UUID, "");
         if(lastUUID.equals("")) {
             Log.d(TAG, "stopWorker: no worker to stop!");
             return;
@@ -99,7 +99,7 @@ public class PingService extends Service {
 
 
     private void registerObserver(String command){
-        String lastUUID = spg.getSharedPreference(SPType.ping_sp).getString(PING_LAST_UUID, null);
+        String lastUUID = spg.getSharedPreference(SPType.PING).getString(PING_LAST_UUID, null);
         if(lastUUID != null) {
             UUID lastUUIDUUID = UUID.fromString(lastUUID);
             LiveData<WorkInfo> liveData =  workManager.getWorkInfoByIdLiveData(lastUUIDUUID);
@@ -109,7 +109,7 @@ public class PingService extends Service {
                 switch (workInfo.getState()){
                     case SUCCEEDED:
                     case FAILED:
-                        if(spg.getSharedPreference(SPType.ping_sp).getBoolean("repeat_ping", false)){
+                        if(spg.getSharedPreference(SPType.PING).getBoolean("repeat_ping", false)){
                             Log.d(TAG, "registerObserver: Repeat ping");
                             startWorker(command);
                         } else {
@@ -145,7 +145,7 @@ public class PingService extends Service {
             Log.d(TAG, "onStartCommand: Intent is null, stopping service");
             workManager.cancelAllWorkByTag(PingWorker.TAG);
             stopSelf();
-            spg.getSharedPreference(SPType.ping_sp).edit().putBoolean("ping_running", false).apply();
+            spg.getSharedPreference(SPType.PING).edit().putBoolean("ping_running", false).apply();
             return START_NOT_STICKY;
         }
         String command = intent.getStringExtra(PING_INTENT_COMMAND);
@@ -153,10 +153,10 @@ public class PingService extends Service {
         if(!isEnabled){
             stopWorker();
             stopSelf();
-            spg.getSharedPreference(SPType.ping_sp).edit().putBoolean("ping_running", false).apply();
+            spg.getSharedPreference(SPType.PING).edit().putBoolean("ping_running", false).apply();
             return START_NOT_STICKY;
         }
-        String lastUUID = spg.getSharedPreference(SPType.ping_sp).getString(PING_LAST_UUID, "");
+        String lastUUID = spg.getSharedPreference(SPType.PING).getString(PING_LAST_UUID, "");
         if(!lastUUID.isEmpty()){
             stopWorker();
         }

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Preferences/SPType.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Preferences/SPType.java
@@ -9,54 +9,36 @@
 package de.fraunhofer.fokus.OpenMobileNetworkToolkit.Preferences;
 
 public enum SPType {
-    logging_sp,
-    iperf3_sp,
-    ping_sp,
-    carrier_sp,
-    mobile_network_sp,
-    default_sp,
-    mqtt_sp;
+    LOGGING,
+    IPERF3,
+    PING,
+    CARRIER,
+    MOBILE_NETWORK,
+    MAIN,
+    MQTT;
 
 
     public String toString() {
         switch(this){
-            case default_sp:
-                return "Default_Settings";
-            case logging_sp:
-                return "Logging_Settings";
-            case ping_sp:
-                return "Ping_Settings";
-            case carrier_sp:
-                return "Carrier_Settings";
-            case mqtt_sp:
-                return "MQTT_Settings";
-            case mobile_network_sp:
-                return "Mobile_Network_Settings";
-            case iperf3_sp:
-                return "iPerf3_Settings";
+            case MAIN:
+                return "main";
+            case LOGGING:
+                return "logging";
+            case MQTT:
+                return "mqtt";
+            case MOBILE_NETWORK:
+                return "mobile_network";
+            case PING:
+                return "ping";
+            case IPERF3:
+                return "iperf3";
+            case CARRIER:
+                return "carrier";
             default:
                 return "";
         }
     }
-    public static SPType fromString(String text) {
-        switch (text){
-            case "Default_Settings":
-                return default_sp;
-            case "Logging_Settings":
-                return logging_sp;
-            case "Ping_Settings":
-                return ping_sp;
-            case "Carrier_Settings":
-                return carrier_sp;
-            case "MQTT_Settings":
-                return mqtt_sp;
-            case "Mobile_Network_Settings":
-                return mobile_network_sp;
-            case "iPerf3 Settings":
-                return iperf3_sp;
-        }
-        return null;
-    }
+
 
 
 }

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Preferences/SPType.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Preferences/SPType.java
@@ -21,43 +21,42 @@ public enum SPType {
     public String toString() {
         switch(this){
             case default_sp:
-                return "preferences";
+                return "Default_Settings";
             case logging_sp:
+                return "Logging_Settings";
             case ping_sp:
+                return "Ping_Settings";
             case carrier_sp:
+                return "Carrier_Settings";
             case mqtt_sp:
+                return "MQTT_Settings";
             case mobile_network_sp:
-                return super.toString();
+                return "Mobile_Network_Settings";
+            case iperf3_sp:
+                return "iPerf3_Settings";
             default:
                 return "";
         }
     }
     public static SPType fromString(String text) {
-        for (SPType b : SPType.values()) {
-            if (b.toString().equalsIgnoreCase(text)) {
-                return b;
-            }
+        switch (text){
+            case "Default_Settings":
+                return default_sp;
+            case "Logging_Settings":
+                return logging_sp;
+            case "Ping_Settings":
+                return ping_sp;
+            case "Carrier_Settings":
+                return carrier_sp;
+            case "MQTT_Settings":
+                return mqtt_sp;
+            case "Mobile_Network_Settings":
+                return mobile_network_sp;
+            case "iPerf3 Settings":
+                return iperf3_sp;
         }
         return null;
     }
 
-    public String toReadable(){
-        String name = this.name().split("_")[0];
-        switch(this){
-            case logging_sp:
-            case ping_sp:
-            case carrier_sp:
 
-            case default_sp:
-                return name.substring(0,1).toUpperCase() + name.substring(1);
-            case mobile_network_sp:
-                return "Mobile Network";
-            case iperf3_sp:
-                return "iPerf3";
-            case mqtt_sp:
-                return "MQTT";
-            default:
-                return null;
-        }
-    }
 }

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Preferences/SharedPreferencesGrouper.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Preferences/SharedPreferencesGrouper.java
@@ -47,12 +47,12 @@ public class SharedPreferencesGrouper {
 
     private SharedPreferencesGrouper( Context ct) {
         this.ct = ct;
-        loggingSP = ct.getSharedPreferences(getSharedPreferenceIdentifier(SPType.logging_sp), Context.MODE_PRIVATE);
-        carrierSP = ct.getSharedPreferences(getSharedPreferenceIdentifier(SPType.carrier_sp), Context.MODE_PRIVATE);
-        iperf3SP = ct.getSharedPreferences(getSharedPreferenceIdentifier(SPType.iperf3_sp), Context.MODE_PRIVATE);
-        pingSP = ct.getSharedPreferences(getSharedPreferenceIdentifier(SPType.ping_sp), Context.MODE_PRIVATE);
-        mqttSP = ct.getSharedPreferences(getSharedPreferenceIdentifier(SPType.mqtt_sp), Context.MODE_PRIVATE);
-        mobileNetworkSP = ct.getSharedPreferences(getSharedPreferenceIdentifier(SPType.mobile_network_sp), Context.MODE_PRIVATE);
+        loggingSP = ct.getSharedPreferences(getSharedPreferenceIdentifier(SPType.LOGGING), Context.MODE_PRIVATE);
+        carrierSP = ct.getSharedPreferences(getSharedPreferenceIdentifier(SPType.CARRIER), Context.MODE_PRIVATE);
+        iperf3SP = ct.getSharedPreferences(getSharedPreferenceIdentifier(SPType.IPERF3), Context.MODE_PRIVATE);
+        pingSP = ct.getSharedPreferences(getSharedPreferenceIdentifier(SPType.PING), Context.MODE_PRIVATE);
+        mqttSP = ct.getSharedPreferences(getSharedPreferenceIdentifier(SPType.MQTT), Context.MODE_PRIVATE);
+        mobileNetworkSP = ct.getSharedPreferences(getSharedPreferenceIdentifier(SPType.MOBILE_NETWORK), Context.MODE_PRIVATE);
         defaultSP = PreferenceManager.getDefaultSharedPreferences(ct);
     }
 
@@ -66,22 +66,22 @@ public class SharedPreferencesGrouper {
     public SharedPreferences getSharedPreference(SPType key){
         SharedPreferences sp;
         switch (key) {
-            case logging_sp:
+            case LOGGING:
                 sp = loggingSP;
                 break;
-            case carrier_sp:
+            case CARRIER:
                 sp = carrierSP;
                 break;
-            case iperf3_sp:
+            case IPERF3:
                 sp = iperf3SP;
                 break;
-            case ping_sp:
+            case PING:
                 sp = pingSP;
                 break;
-            case mobile_network_sp:
+            case MOBILE_NETWORK:
                 sp = mobileNetworkSP;
                 break;
-            case mqtt_sp:
+            case MQTT:
                 sp = mqttSP;
                 break;
             default:

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Preferences/SharedPreferencesIO.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Preferences/SharedPreferencesIO.java
@@ -10,86 +10,155 @@ package de.fraunhofer.fokus.OpenMobileNetworkToolkit.Preferences;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.content.res.Resources;
 import android.util.Log;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import de.fraunhofer.fokus.OpenMobileNetworkToolkit.DataProvider.BuildInformation;
+import de.fraunhofer.fokus.OpenMobileNetworkToolkit.R;
 
 public class SharedPreferencesIO {
 
     private static final String TAG = "SharedPreferencesIO";
 
     public static String exportPreferences(Context context) {
-        HashMap<SPType,SharedPreferences> sharedPreferences = SharedPreferencesGrouper.getInstance(context).getAllSharedPreferences();
-        JSONObject preferencesJson = new JSONObject();
-        for(SPType key : sharedPreferences.keySet()) {
-            SharedPreferences prefs = sharedPreferences.get(key);
-            JSONObject spJSON = new JSONObject(prefs.getAll());
-            try {
-                preferencesJson.put(key.toString(), spJSON);
-            } catch (JSONException e) {
-                Log.e(TAG, "Failed to export preference "+key, e);
-            }
+        JSONArray jsonArray = null;
+        try (InputStream is = context.getResources().openRawResource(R.raw.config);
+             BufferedReader reader = new BufferedReader(new InputStreamReader(is))) {
+            String json = reader.lines().collect(Collectors.joining());
+            jsonArray = new JSONArray(json);
+
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to read or parse JSON array from config file", e);
+            return "";
         }
+
+        SharedPreferencesGrouper spg = SharedPreferencesGrouper.getInstance(context);
         try {
-            preferencesJson.put("BuildInformation", new BuildInformation().toJSON());
-            return preferencesJson.toString(4);
-        } catch (JSONException e) {
-            Log.e(TAG, "Failed to Preference JSON to String", e);
-            return "{}";
+            for (int i = 0; i < jsonArray.length(); i++) {
+                JSONObject settingObject = jsonArray.getJSONObject(i);
+                if(settingObject.has("metadata")) continue;
+                String settingName = settingObject.getString("setting");
+                JSONArray categoriesArray = settingObject.getJSONArray("categories");
+                SPType spType = SPType.valueOf(settingName.toUpperCase());
+                if(spType == null) {
+                    Log.w(TAG, "Unknown SPType: " + settingName);
+                    continue;
+                }
+                for (int j = 0; j < categoriesArray.length(); j++) {
+                    JSONObject categorieObject = categoriesArray.getJSONObject(j);
+                    JSONArray preferenceArray = categorieObject.getJSONArray("preferences");
+                    for (int k = 0; k < preferenceArray.length(); k++) {
+                        JSONObject preferenceObject = preferenceArray.getJSONObject(k);
+                        getValue(preferenceObject, spg.getSharedPreference(spType));
+                    }
+                }
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to import preferences", e);
+            Toast.makeText(context, "Failed to import preferences", Toast.LENGTH_SHORT).show();
         }
+
+        return jsonArray.toString();
+
     }
 
+    private static void getValue(JSONObject jsonObject, SharedPreferences sp){
+        try{
+            String type = jsonObject.getString("type");
+            String key = jsonObject.getString("key");
+            switch (type){
+                case "string":
+                    jsonObject.put("value", sp.getString(key, ""));
+                    break;
+                case "boolean":
+                    jsonObject.put("value", sp.getBoolean(key, false));
+                    break;
+                case "set":
+                    JSONArray jsonArray = new JSONArray();
+                    Set<String> stringSet = sp.getStringSet(key, new HashSet<>());
+                    for (String string: stringSet) {
+                        jsonArray.put(string);
+                    }
+                    jsonObject.put("value", jsonArray);
+                default:
+                    Log.e(TAG, "getValue: could not get value of type: "+type);
+                    break;
+            }
+        } catch (JSONException e) {
+            Log.e(TAG, "getValue: could not get data from JSON object");;
+        }
+    }
+    private static void putValue(JSONObject jsonObject, SharedPreferences sp){
+        try{
+            String type = jsonObject.getString("type");
+            String key = jsonObject.getString("key");
+            switch (type){
+                case "string":
+                    sp.edit().putString(key, jsonObject.getString("value")).apply();
+                    break;
+                case "boolean":
+                    sp.edit().putBoolean(key, jsonObject.getBoolean("value")).apply();
+                    break;
+                case "set":
+                    Set<String> stringSet = new HashSet<>();
+                    JSONArray jsonArray = jsonObject.getJSONArray("value");
+                    if(jsonArray == null || jsonArray.length() == 0){
+                        break;
+                    }
+                    for (int i = 0; i < jsonArray.length(); i++) {
+                        stringSet.add(jsonArray.getString(i));
+                    }
+                    sp.edit().putStringSet(key, stringSet);
+                default:
+                    Log.e(TAG, "putValue: could not put value of type: "+type);
+                    break;
+            }
+        } catch (JSONException e) {
+            Log.e(TAG, "putValue: could not get data from JSON object");;
+        }
+    }
     public static void importPreferences(Context context, String jsonString) {
+        SharedPreferencesGrouper spg = SharedPreferencesGrouper.getInstance(context);
         try {
-            JSONObject spJSON = new JSONObject(jsonString);
-
-            spJSON.keys().forEachRemaining(key -> {
-                SPType spType = SPType.fromString(key);
-                if (spType == null) {
-                    Log.e(TAG, "Unknown preference type: " + key);
-                    return;
+            JSONArray spJSON = new JSONArray(jsonString);
+            for (int i = 0; i < spJSON.length(); i++) {
+                JSONObject settingObject = spJSON.getJSONObject(i);
+                if(settingObject.has("metadata")) continue;
+                String settingName = settingObject.getString("setting");
+                JSONArray categoriesArray = settingObject.getJSONArray("categories");
+                SPType spType = SPType.valueOf(settingName.toUpperCase());
+                if(spType == null) {
+                    Log.w(TAG, "Unknown SPType: " + settingName);
+                    continue;
                 }
-                SharedPreferences prefs = SharedPreferencesGrouper.getInstance(context).getSharedPreference(spType);
-                SharedPreferences.Editor editor = prefs.edit();
-                @NonNull JSONObject preferences;
-                try {
-                    preferences = spJSON.getJSONObject(key);
-                } catch (JSONException e) {
-                    Log.e(TAG, "Failed to get preferences for: " + key, e);
-                    return;
-                }
-                preferences.keys().forEachRemaining(preferenceKey -> {
-                    @NonNull Object value;
-                    try {
-                        value = preferences.get(preferenceKey);
-                    } catch (JSONException e) {
-                        Log.e(TAG, "Failed to get value for: " + preferenceKey, e);
-                        return;
+                for (int j = 0; j < categoriesArray.length(); j++) {
+                    JSONObject categorieObject = categoriesArray.getJSONObject(j);
+                    JSONArray preferenceArray = categorieObject.getJSONArray("preferences");
+                    for (int k = 0; k < preferenceArray.length(); k++) {
+                        JSONObject preferenceObject = preferenceArray.getJSONObject(k);
+                        putValue(preferenceObject, spg.getSharedPreference(spType));
                     }
-                    if (value instanceof Boolean) {
-                        editor.putBoolean(preferenceKey, (Boolean) value);
-                    } else if (value instanceof Float) {
-                        editor.putFloat(preferenceKey, (Float) value);
-                    } else if (value instanceof Integer) {
-                        editor.putInt(preferenceKey, (Integer) value);
-                    } else if (value instanceof Long) {
-                        editor.putLong(preferenceKey, (Long) value);
-                    } else if (value instanceof String) {
-                        editor.putString(preferenceKey, (String) value);
-                    }
-                });
-                editor.apply();
-                Log.d(TAG, "Imported: " + key);
-            });
 
+                }
+            }
         } catch (Exception e) {
             Log.e(TAG, "Failed to import preferences", e);
             Toast.makeText(context, "Failed to import preferences", Toast.LENGTH_SHORT).show();

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Preferences/SharedPreferencesIOFragment.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Preferences/SharedPreferencesIOFragment.java
@@ -264,7 +264,7 @@ public class SharedPreferencesIOFragment extends Fragment implements ClearPrefer
         headerLayout.setPadding(16, 16, 16, 16); // Add padding
 
         TextView typeTextView = new TextView(context);
-        typeTextView.setText(type.toReadable());
+        typeTextView.setText(type.toString().replace("_", " "));
         typeTextView.setTextSize(18);
         typeTextView.setTypeface(typeTextView.getTypeface(), Typeface.BOLD);
         typeTextView.setTextColor(context.getColor(R.color.design_default_color_primary));

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Preferences/SharedPreferencesIOFragment.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/Preferences/SharedPreferencesIOFragment.java
@@ -41,7 +41,6 @@ import java.io.File;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -50,6 +49,7 @@ import de.fraunhofer.fokus.OpenMobileNetworkToolkit.MultiSelectDialogFragment;
 import de.fraunhofer.fokus.OpenMobileNetworkToolkit.R;
 import de.fraunhofer.fokus.OpenMobileNetworkToolkit.SettingPreferences.ClearPreferencesListener;
 
+import org.json.JSONArray;
 import org.json.JSONObject;
 
 public class SharedPreferencesIOFragment extends Fragment implements ClearPreferencesListener {
@@ -154,6 +154,8 @@ public class SharedPreferencesIOFragment extends Fragment implements ClearPrefer
         LinearLayout preferencesLayout = new LinearLayout(context);
         preferencesLayout.setOrientation(LinearLayout.VERTICAL);
         for (Map.Entry<SPType, SharedPreferences> spEntry : SharedPreferencesGrouper.getInstance(context).getAllSharedPreferences().entrySet()) {
+            SPType spType = spEntry.getKey();
+            if(spType.equals(SPType.IPERF3) || spType.equals(SPType.PING) || spType.equals(SPType.CARRIER)) continue;
             preferencesLayout.addView(generateSharedPreferencesView(spEntry.getKey(), spEntry.getValue()));
         }
 
@@ -194,13 +196,12 @@ public class SharedPreferencesIOFragment extends Fragment implements ClearPrefer
     private List<String> getKeysFromJson(String jsonString) {
         List<String> keys = new ArrayList<>();
         try {
-            JSONObject jsonObject = new JSONObject(jsonString);
-            Iterator<String> iter = jsonObject.keys();
-            while (iter.hasNext()) {
-                String current = iter.next();
-                if (SPType.fromString(current) != null) {
-                    keys.add(current);
-                }
+            JSONArray jsonArray = new JSONArray(jsonString);
+            for (int i = 0; i < jsonArray.length(); i++) {
+                JSONObject setting = jsonArray.getJSONObject(i);
+                if(setting.has("metadata")) continue;
+                String settingString = setting.getString("setting");
+                keys.add(settingString);
             }
 
         } catch (Exception e) {
@@ -231,12 +232,17 @@ public class SharedPreferencesIOFragment extends Fragment implements ClearPrefer
     private @NonNull MultiSelectDialogFragment getMultiSelectDialogFragment(String jsonString, List<String> keys) {
         MultiSelectDialogFragment.OnMultiSelectListener listener = selectedItems -> {
             try {
-                JSONObject jsonObject = new JSONObject(jsonString);
-                JSONObject filteredJsonObject = new JSONObject();
-                for (String key : selectedItems) {
-                    filteredJsonObject.put(key, jsonObject.get(key));
+                JSONArray jsonArray = new JSONArray(jsonString);
+                JSONArray filteredjsonArray = new JSONArray();
+                for (int i = 0; i < jsonArray.length(); i++) {
+                    JSONObject jsonObject = jsonArray.getJSONObject(i);
+                    if(jsonObject.has("metadata")) continue;
+                    String setting = jsonObject.getString("setting");
+                    if(!selectedItems.contains(setting)) continue;
+                    filteredjsonArray.put(jsonObject);
+
                 }
-                SharedPreferencesIO.importPreferences(context, filteredJsonObject.toString());
+                SharedPreferencesIO.importPreferences(context, filteredjsonArray.toString());
                 onPreferenceChanged();
                 showToast("Config imported");
             } catch (Exception e) {

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/QuickFragment.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/QuickFragment.java
@@ -375,7 +375,7 @@ public class QuickFragment extends Fragment {
             } else {
                 cellInformationList.forEach(cellInformation -> addCellInformationToView(cellInformation));
             }
-            if (spg.getSharedPreference(SPType.default_sp).getBoolean("show_neighbour_cells", false)) {
+            if (spg.getSharedPreference(SPType.MAIN).getBoolean("show_neighbour_cells", false)) {
                 if(!neighborCells.isEmpty()){
                     neighborCells.forEach(cellInformation -> addCellInformationToView(cellInformation));
                 }

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/SettingPreferences/LoggingSettingsFragment.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/SettingPreferences/LoggingSettingsFragment.java
@@ -31,7 +31,7 @@ public class LoggingSettingsFragment extends PreferenceFragmentCompat
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
         SharedPreferencesGrouper spg = SharedPreferencesGrouper.getInstance(requireContext());
-        getPreferenceManager().setSharedPreferencesName(spg.getSharedPreferenceIdentifier(SPType.logging_sp));
+        getPreferenceManager().setSharedPreferencesName(spg.getSharedPreferenceIdentifier(SPType.LOGGING));
         setPreferencesFromResource(R.xml.preference_logging, rootKey);
         Objects.requireNonNull(getPreferenceScreen().getSharedPreferences())
             .registerOnSharedPreferenceChangeListener(this);

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/SettingPreferences/MQTTSettingsFragment.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/SettingPreferences/MQTTSettingsFragment.java
@@ -10,7 +10,6 @@ package de.fraunhofer.fokus.OpenMobileNetworkToolkit.SettingPreferences;
 
 import android.content.SharedPreferences;
 import android.os.Bundle;
-import android.text.InputType;
 import android.util.Log;
 
 import androidx.annotation.Nullable;
@@ -29,7 +28,7 @@ public class MQTTSettingsFragment extends PreferenceFragmentCompat implements Sh
     @Override
     public void onCreatePreferences(@Nullable Bundle savedInstanceState, @Nullable String rootKey) {
         SharedPreferencesGrouper spg = SharedPreferencesGrouper.getInstance(requireContext());
-        getPreferenceManager().setSharedPreferencesName(spg.getSharedPreferenceIdentifier(SPType.mqtt_sp));
+        getPreferenceManager().setSharedPreferencesName(spg.getSharedPreferenceIdentifier(SPType.MQTT));
         setPreferencesFromResource(R.xml.preference_mqtt, rootKey);
         Objects.requireNonNull(getPreferenceScreen().getSharedPreferences())
                 .registerOnSharedPreferenceChangeListener(this);

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/SettingPreferences/MobileNetworkSettingsFragment.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/SettingPreferences/MobileNetworkSettingsFragment.java
@@ -97,7 +97,7 @@ public class MobileNetworkSettingsFragment extends PreferenceFragmentCompat
         ct = requireContext();
         plmnId = ct.getString(R.string.select_plmn);
         accessNetworkType = ct.getString(R.string.access_networktype);
-        preferences = SharedPreferencesGrouper.getInstance(ct).getSharedPreference(SPType.mobile_network_sp);
+        preferences = SharedPreferencesGrouper.getInstance(ct).getSharedPreference(SPType.MOBILE_NETWORK);
         tm = gv.getTm();
         pm = gv.getPm();
         int sdk_version = Build.VERSION.SDK_INT;
@@ -186,7 +186,7 @@ public class MobileNetworkSettingsFragment extends PreferenceFragmentCompat
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
         gv = GlobalVars.getInstance();
-        getPreferenceManager().setSharedPreferencesName(SharedPreferencesGrouper.getInstance(requireContext()).getSharedPreferenceIdentifier(SPType.carrier_sp));
+        getPreferenceManager().setSharedPreferencesName(SharedPreferencesGrouper.getInstance(requireContext()).getSharedPreferenceIdentifier(SPType.MOBILE_NETWORK));
         setPreferencesFromResource(R.xml.preference_mobile_network, rootKey);
         Preference button = getPreferenceManager().findPreference("apply_cs_settings");
         if (button != null) {

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/SettingPreferences/SettingsFragment.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/SettingPreferences/SettingsFragment.java
@@ -40,7 +40,7 @@ public class SettingsFragment extends PreferenceFragmentCompat {
         getPreferenceManager().setSharedPreferencesName(spg.getSharedPreferenceIdentifier(SPType.default_sp));
         pfm.setSharedPreferencesName(spg.getSharedPreferenceIdentifier(SPType.default_sp));
         pfm.setSharedPreferencesMode(Context.MODE_PRIVATE);
-        setPreferencesFromResource(R.xml.preference, rootKey);
+        setPreferencesFromResource(R.xml.preference_main, rootKey);
 
         ListPreference sub_select = pfm.findPreference("select_subscription");
         if (sub_select != null) {

--- a/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/SettingPreferences/SettingsFragment.java
+++ b/app/src/main/java/de/fraunhofer/fokus/OpenMobileNetworkToolkit/SettingPreferences/SettingsFragment.java
@@ -37,8 +37,8 @@ public class SettingsFragment extends PreferenceFragmentCompat {
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
         SharedPreferencesGrouper spg = SharedPreferencesGrouper.getInstance(requireContext());
         PreferenceManager pfm = getPreferenceManager();
-        getPreferenceManager().setSharedPreferencesName(spg.getSharedPreferenceIdentifier(SPType.default_sp));
-        pfm.setSharedPreferencesName(spg.getSharedPreferenceIdentifier(SPType.default_sp));
+        getPreferenceManager().setSharedPreferencesName(spg.getSharedPreferenceIdentifier(SPType.MAIN));
+        pfm.setSharedPreferencesName(spg.getSharedPreferenceIdentifier(SPType.MAIN));
         pfm.setSharedPreferencesMode(Context.MODE_PRIVATE);
         setPreferencesFromResource(R.xml.preference_main, rootKey);
 

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -133,7 +133,7 @@
         android:id="@+id/settingsFragment"
         android:name="de.fraunhofer.fokus.OpenMobileNetworkToolkit.SettingPreferences.SettingsFragment"
         android:label="SettingsFragment"
-        tools:layout="@xml/preference">
+        tools:layout="@xml/preference_main">
         <action
             android:id="@+id/action_settingsFragment2_to_flagSettingFragment"
             app:destination="@id/flagSettingFragment" />

--- a/app/src/main/res/raw/config.json
+++ b/app/src/main/res/raw/config.json
@@ -1,0 +1,519 @@
+[
+    {
+        "setting": "logging",
+        "categories": [
+            {
+                "name": "logging_service",
+                "preferences": [
+                    {
+                        "key": "enable_logging",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "start_logging_on_boot",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "logging_interval",
+                        "value": null,
+                        "type": "string"
+                    }
+                ]
+            },
+            {
+                "name": "local_logging",
+                "preferences": [
+                    {
+                        "key": "enable_local_influx_log",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "enable_local_file_log",
+                        "value": null,
+                        "type": "boolean"
+                    }
+                ]
+            },
+            {
+                "name": "remote_logging",
+                "preferences": [
+                    {
+                        "key": "enable_influx",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "influx_URL",
+                        "value": null,
+                        "type": "string"
+                    },
+                    {
+                        "key": "influx_org",
+                        "value": null,
+                        "type": "string"
+                    },
+                    {
+                        "key": "influx_token",
+                        "value": null,
+                        "type": "string"
+                    },
+                    {
+                        "key": "influx_bucket",
+                        "value": null,
+                        "type": "string"
+                    }
+                ]
+            },
+            {
+                "name": "logging_content",
+                "preferences": [
+                    {
+                        "key": "fake_location",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "measurement_name",
+                        "value": null,
+                        "type": "string"
+                    },
+                    {
+                        "key": "tags",
+                        "value": null,
+                        "type": "string"
+                    },
+                    {
+                        "key": "influx_network_data",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "log_signal_data",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "influx_cell_data",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "log_neighbour_cells",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "influx_throughput_data",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "log_wifi_data",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "influx_battery_data",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "influx_ip_address_data",
+                        "value": null,
+                        "type": "boolean"
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "setting": "main",
+        "categories": [
+            {
+                "name": "home_screen_settings",
+                "preferences": [
+                    {
+                        "key": "show_neighbour_cells",
+                        "value": null,
+                        "type": "boolean"
+                    }
+                ]
+            },
+            {
+                "name": "notification_settings",
+                "preferences": [
+                    {
+                        "key": "enable_radio_notification",
+                        "value": null,
+                        "type": "boolean"
+                    }
+                ]
+            },
+            {
+                "name": "app_settings",
+                "preferences": [
+                    {
+                        "key": "device_name",
+                        "value": null,
+                        "type": "string"
+                    },
+                    {
+                        "key": "select_subscription",
+                        "value": null,
+                        "type": "string"
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "setting": "mqtt",
+        "categories": [
+            {
+                "name": "mqtt_service",
+                "preferences": [
+                    {
+                        "key": "enable_mqtt",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "enable_mqtt_on_boot",
+                        "value": null,
+                        "type": "boolean"
+                    }
+                ]
+            },
+            {
+                "name": "mqtt_credentials",
+                "preferences": [
+                    {
+                        "key": "mqtt_host",
+                        "value": null,
+                        "type": "string"
+                    },
+                    {
+                        "key": "mqtt_client_username",
+                        "value": null,
+                        "type": "string"
+                    },
+                    {
+                        "key": "mqtt_client_password",
+                        "value": null,
+                        "type": "string"
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "setting": "mobile_network",
+        "categories": [
+            {
+                "name": "radio_settings",
+                "preferences": [
+                    {
+                        "key": "select_network_type",
+                        "value": null,
+                        "type": "string"
+                    },
+                    {
+                        "key": "add_plmn",
+                        "value": null,
+                        "type": "string"
+                    },
+                    {
+                        "key": "persist_boot",
+                        "value": null,
+                        "type": "boolean"
+                    }
+                ]
+            },
+            {
+                "name": "android_12_api_31_(s)",
+                "preferences": [
+                    {
+                        "key": "edit_text_EPDG_STATIC_ADDRESS",
+                        "value": null,
+                        "type": "string"
+                    },
+                    {
+                        "key": "multi_select_KEY_CARRIER_NR_AVAILABILITIES_INT_ARRAY",
+                        "value": null,
+                        "type": "set"
+                    },
+                    {
+                        "key": "switch_KEY_HIDE_TTY_HCO_VCO_WITH_RTT_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_HIDE_ENABLE_2G",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_RTT_UPGRADE_SUPPORTED_FOR_DOWNGRADED_VT_CALL_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    }
+                ]
+            },
+            {
+                "name": "android_11_api_30_(r)",
+                "preferences": [
+                    {
+                        "key": "switch_KEY_ALLOW_VIDEO_CALLING_FALLBACK_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_CARRIER_DEFAULT_WFC_IMS_ENABLED_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_HIDE_LTE_PLUS_DATA_ICON_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_WORLD_MODE_ENABLED_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_CARRIER_RCS_PROVISIONING_REQUIRED_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_SHOW_IMS_REGISTRATION_STATUS_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_EDITABLE_WFC_MODE_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_EDITABLE_WFC_ROAMING_MODE_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "edit_text_KEY_READ_ONLY_APN_FIELDS_STRING_ARRAY",
+                        "value": null,
+                        "type": "string"
+                    },
+                    {
+                        "key": "edit_text_KEY_APN_SETTINGS_DEFAULT_APN_TYPES_STRING_ARRAY",
+                        "value": null,
+                        "type": "string"
+                    },
+                    {
+                        "key": "switch_KEY_CARRIER_ALLOW_DEFLECT_IMS_CALL_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    }
+                ]
+            },
+            {
+                "name": "android_10_api_29_(q)",
+                "preferences": [
+                    {
+                        "key": "switch_KEY_FORCE_HOME_NETWORK_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_PREFER_2G_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_CARRIER_SETTINGS_ENABLE_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_CARRIER_ALLOW_TURNOFF_IMS_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_CARRIER_WFC_IMS_AVAILABLE_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_EDITABLE_ENHANCED_4G_LTE_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_CARRIER_VOLTE_AVAILABLE_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_CARRIER_VOLTE_PROVISIONING_REQUIRED_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_CARRIER_VOLTE_PROVISIONED_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_CARRIER_VT_AVAILABLE_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_CARRIER_VOLTE_TTY_SUPPORTED_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_HIDE_ENHANCED_4G_LTE_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_HIDE_CARRIER_NETWORK_SETTINGS_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_HIDE_IMS_APN_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_HIDE_PREFERRED_NETWORK_TYPE_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_HIDE_PRESET_APN_DETAILS_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_HIDE_SIM_LOCK_SETTINGS_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_ALLOW_ADDING_APNS_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_APN_EXPAND_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_CARRIER_WFC_SUPPORTS_WIFI_ONLY_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_CARRIER_IMS_GBA_REQUIRED_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_REQUIRE_ENTITLEMENT_CHECKS_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "list_KEY_VOLTE_REPLACEMENT_RAT_INT9",
+                        "value": null,
+                        "type": "string"
+                    },
+                    {
+                        "key": "switch_KEY_CARRIER_USE_IMS_FIRST_FOR_EMERGENCY_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_AUTO_RETRY_ENABLED_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_WORLD_PHONE_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_SUPPORT_PAUSE_IMS_VIDEO_CALLS_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_CARRIER_UT_PROVISIONING_REQUIRED_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_CARRIER_SUPPORTS_SS_OVER_UT_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_ENHANCED_4G_LTE_ON_BY_DEFAULT_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_SUPPORT_EMERGENCY_SMS_OVER_IMS_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "list_KEY_CARRIER_DEFAULT_WFC_IMS_MODE_INT",
+                        "value": null,
+                        "type": "string"
+                    },
+                    {
+                        "key": "list_KEY_CARRIER_DEFAULT_WFC_IMS_ROAMING_MODE_INT",
+                        "value": null,
+                        "type": "string"
+                    },
+                    {
+                        "key": "switch_KEY_ALLOW_EMERGENCY_VIDEO_CALLS_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    }
+                ]
+            },
+            {
+                "name": "android_8_api_27_(0_mr1)",
+                "preferences": [
+                    {
+                        "key": "switch_KEY_DISPLAY_HD_AUDIO_PROPERTY_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "metadata": {
+            "version": "0.7",
+            "code": 7,
+            "gitHash": "9d3ed7b"
+        }
+    }
+]

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -104,7 +104,7 @@
     <string name="exit">Exit\n</string>
     <string name="action_xiaomi">xiaomi</string>
     <string name="carrier_settings_summary">Applied on SIM / network change</string>
-    <string name="show_neighbour_cells">Show neighbour cells\n</string>
+    <string name="show_neighbour_cells">Show neighbour cells</string>
     <string name="home_screen_settings">Home screen settings</string>
     <string name="app_settings">App settings</string>
     <string name="action_android_ims">Android IMS</string>>
@@ -258,6 +258,26 @@
     <string name="influx_battery_data_summary">This will log BatteryInformation data to InfluxDB. Like BatteryLevel and Charging Status.</string>
     <string name="influx_ip_address_data_summary">This will log IPAddressInformation data to InfluxDB. Like IPv4 and IPv6 addresses, and the interface name.</string>
     <string name="open_for_link_to_documentation">Click here for Android Doc</string>
+    <string name="influx_preference_summary">This configures a remote InfluxDB instance to log data to.</string>
+    <string name="local_logging_preference_summary">This configures a local InfluxDB instance, running on the Device, to log data to. EXPERIMENTAL</string>
+    <string name="logging_service_summary">This configures the logging Service of OMNT.</string>
+    <string name="influx_url_summary">Influx URL, it can either be http://IP:8086, https://IP:8086, or any hostname.</string>
+    <string name="influx_org_summary">Influx ORG Name, or ID.</string>
+    <string name="influx_token_summary">Influx TOKEN</string>
+    <string name="influx_bucket_summary">Influx Bucket Name or ID.</string>
+    <string name="mqtt_summary">Enables MQTT Services for OMNT.</string>
+    <string name="mqtt_credentials_summary">Section to set Credentials for MQTT.</string>
+    <string name="mqtt_host_summary">MQTT Broker Address</string>
+    <string name="mqtt_client_password_summary">MQTT Client Password.</string>
+    <string name="radio_setting_documentation_summary">Opens Link to Android Doc.</string>
+    <string name="access_networktype_summary">Select Network Type</string>
+    <string name="prefernce_show_neighbour_cells_summary">Shows Neighbour cells only when connected to a Network and is announced by the network.</string>
+    <string name="device_name_summary">Set unique device name.</string>
+    <string name="log_settings_summary">Configure the Logging Parameter.</string>
+    <string name="mobile_network_settings_summary">Configure Mobile Network Settings, only if the App has Carrier Permissions.</string>
+    <string name="reset_modem_summary">Reboots the modem, only possible when OMNT has Carrier Permissions.</string>
+    <string name="mqtt_settings_summary">Configure MQTT for OMNT.</string>
+    <string name="shared_preferences_io_summary">Import/Export Config of OMNT.</string>
 
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -271,7 +271,7 @@
     <string name="mqtt_client_password_summary">MQTT Client Password.</string>
     <string name="radio_setting_documentation_summary">Opens Link to Android Doc.</string>
     <string name="access_networktype_summary">Select Network Type</string>
-    <string name="prefernce_show_neighbour_cells_summary">Shows Neighbour cells only when connected to a Network and is announced by the network.</string>
+    <string name="prefernce_show_neighbour_cells_summary">Shows neighbour cells only when connected to a network and is announced by the network.</string>
     <string name="device_name_summary">Set unique device name.</string>
     <string name="log_settings_summary">Configure the Logging Parameter.</string>
     <string name="mobile_network_settings_summary">Configure Mobile Network Settings, only if the App has Carrier Permissions.</string>

--- a/app/src/main/res/xml/preference_logging.xml
+++ b/app/src/main/res/xml/preference_logging.xml
@@ -13,16 +13,19 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:title="Logging Service"
+        android:summary="@string/logging_service_summary"
         app:iconSpaceReserved="false">
 
         <SwitchPreferenceCompat
             app:iconSpaceReserved="false"
             app:key="enable_logging"
             app:summary="@string/enable_logging_summary"
+            android:defaultValue="false"
             app:title="@string/enable_logging" />
         <SwitchPreferenceCompat
             app:iconSpaceReserved="false"
             app:key="start_logging_on_boot"
+            android:defaultValue="false"
             app:summary="@string/start_logging_on_boot_summary"
             app:title="@string/start_logging_on_boot" />
         <EditTextPreference
@@ -38,16 +41,19 @@
     <PreferenceCategory
         app:iconSpaceReserved="false"
         app:key="local_log_category"
+        android:summary="@string/local_logging_preference_summary"
         app:title="Local logging">
 
         <SwitchPreferenceCompat
             app:enabled="false"
             app:iconSpaceReserved="false"
             app:key="enable_local_influx_log"
+            android:defaultValue="fals"
             app:summary="@string/enable_local_log_summary"
             app:title="@string/enable_local_log" />
         <SwitchPreferenceCompat
             app:iconSpaceReserved="false"
+            android:defaultValue="false"
             app:key="enable_local_file_log"
             app:summary="@string/enable_local_file_summary"
             app:title="@string/enable_local_file_log" />
@@ -56,11 +62,13 @@
     <PreferenceCategory
         app:iconSpaceReserved="false"
         app:key="influx_category"
+        android:summary="@string/influx_preference_summary"
         app:title="Remote logging">
 
         <SwitchPreferenceCompat
             app:iconSpaceReserved="false"
             app:key="enable_influx"
+            android:defaultValue="false"
             app:summary="@string/enable_influx_summary"
             app:title="@string/enable_influx" />
 
@@ -69,6 +77,8 @@
             app:iconSpaceReserved="false"
             app:key="influx_URL"
             app:title="@string/influx_url"
+            android:defaultValue="http://IP:8086"
+            app:summary="@string/influx_url_summary"
             app:useSimpleSummaryProvider="true" />
 
         <EditTextPreference
@@ -76,6 +86,8 @@
             app:iconSpaceReserved="false"
             app:key="influx_org"
             app:title="@string/influx_org"
+            android:summary="@string/influx_org_summary"
+            android:defaultValue="ORG"
             app:useSimpleSummaryProvider="true" />
 
         <EditTextPreference
@@ -83,13 +95,17 @@
             app:iconSpaceReserved="false"
             app:key="influx_token"
             app:title="@string/influx_token"
+            android:summary="@string/influx_token_summary"
+            android:defaultValue="TOKEN"
             app:useSimpleSummaryProvider="true" />
 
         <EditTextPreference
             android:dialogTitle="@string/influx_bucket_dialog_title"
             app:iconSpaceReserved="false"
             app:key="influx_bucket"
+            android:summary="@string/influx_bucket_summary"
             app:title="@string/influx_bucket"
+            android:defaultValue="BUCKET_NAME"
             app:useSimpleSummaryProvider="true" />
     </PreferenceCategory>
 
@@ -101,6 +117,7 @@
         <SwitchPreferenceCompat
             app:iconSpaceReserved="false"
             app:key="fake_location"
+            android:defaultValue="false"
             app:summary="@string/fake_location_summary"
             app:title="@string/fake_location" />
 
@@ -108,6 +125,7 @@
         <EditTextPreference
             app:iconSpaceReserved="false"
             app:key="measurement_name"
+            android:defaultValue="omnt"
             app:title="@string/measurement"
             app:useSimpleSummaryProvider="true" />
 
@@ -116,42 +134,44 @@
             app:key="tags"
             app:summary="@string/tags_summary"
             app:title="@string/tags"
+            android:defaultValue=""
             app:useSimpleSummaryProvider="true" />
 
         <SwitchPreferenceCompat
             app:iconSpaceReserved="false"
             app:key="influx_network_data"
+            android:defaultValue="false"
             app:summary="@string/influx_network_data_summary"
             app:title="@string/influx_network_data" />
 
         <SwitchPreferenceCompat
             app:iconSpaceReserved="false"
             app:key="log_signal_data"
+            android:defaultValue="false"
             app:summary="@string/log_signal_data_summary"
             app:title="@string/log_signal_data" />
 
         <SwitchPreferenceCompat
-
             app:iconSpaceReserved="false"
             app:key="influx_cell_data"
+            android:defaultValue="true"
             app:summary="@string/influx_cell_data_summary"
             app:title="@string/influx_cell_data" />
 
         <SwitchPreferenceCompat
-
             app:dependency="influx_cell_data"
             app:iconSpaceReserved="false"
             app:key="log_neighbour_cells"
+            android:defaultValue="false"
             app:summary="@string/log_neighbour_cells_summary"
             app:title="@string/log_neighbour_cells" />
         <SwitchPreferenceCompat
-
             app:iconSpaceReserved="false"
             app:key="influx_throughput_data"
+            android:defaultValue="false"
             app:summary="@string/influx_throughput_data_summary"
             app:title="@string/influx_throughput_data" />
         <SwitchPreferenceCompat
-
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:defaultValue="false"

--- a/app/src/main/res/xml/preference_main.xml
+++ b/app/src/main/res/xml/preference_main.xml
@@ -18,6 +18,7 @@
         <SwitchPreferenceCompat
             android:defaultValue="false"
             android:key="show_neighbour_cells"
+            android:summary="@string/prefernce_show_neighbour_cells_summary"
             android:title="@string/show_neighbour_cells"
             app:allowDividerAbove="false"
             app:allowDividerBelow="false"
@@ -30,6 +31,7 @@
         <SwitchPreferenceCompat
             app:iconSpaceReserved="false"
             app:key="enable_radio_notification"
+            android:defaultValue="false"
             app:summary="@string/enable_radio_notification_summary"
             app:title="@string/enable_radio_notification" />
     </PreferenceCategory>
@@ -41,6 +43,8 @@
     <EditTextPreference
         android:icon="@drawable/baseline_android_24"
         app:key="device_name"
+        android:defaultValue="OMNT0001"
+        android:summary="@string/device_name_summary"
         app:title="@string/device_name"
         app:useSimpleSummaryProvider="true"
         />
@@ -48,12 +52,14 @@
         android:icon="@drawable/ic_baseline_code_24"
         app:fragment="de.fraunhofer.fokus.OpenMobileNetworkToolkit.SettingPreferences.LoggingSettingsFragment"
         app:key="log_settings"
+        android:summary="@string/log_settings_summary"
         app:dependency="device_name"
         app:title="Logging" />
     <Preference
         android:icon="@drawable/baseline_cell_tower_24"
         app:fragment="de.fraunhofer.fokus.OpenMobileNetworkToolkit.SettingPreferences.MobileNetworkSettingsFragment"
         app:key="mobile_network_settings"
+        android:summary="@string/mobile_network_settings_summary"
         app:title="Mobile Network" />
     <ListPreference
         android:layout_width="wrap_content"
@@ -66,17 +72,20 @@
     <Preference
         android:icon="@drawable/baseline_restart_alt_24"
         app:key="reset_modem"
+        android:summary="@string/reset_modem_summary"
         app:title="Reboot Modem" />
     <Preference
         android:icon="@drawable/mqtt"
         app:fragment="de.fraunhofer.fokus.OpenMobileNetworkToolkit.SettingPreferences.MQTTSettingsFragment"
         app:key="mqtt_settings"
+        android:summary="@string/mqtt_settings_summary"
         app:dependency="device_name"
         app:title="MQTT Settings" />
     <Preference
         android:icon="@drawable/ic_action_share_blue"
         app:fragment="de.fraunhofer.fokus.OpenMobileNetworkToolkit.SettingPreferences.SharedPreferencesIOFragment"
         app:key="shared_preferences_io"
+        android:summary="@string/shared_preferences_io_summary"
         app:title="Config" />
 
     </PreferenceCategory>

--- a/app/src/main/res/xml/preference_mobile_network.xml
+++ b/app/src/main/res/xml/preference_mobile_network.xml
@@ -16,6 +16,7 @@
             app:iconSpaceReserved="false">
                 <Preference
                     app:key="doc"
+                    android:summary="@string/radio_setting_documentation_summary"
                     app:title="@string/open_for_link_to_documentation"
                     app:iconSpaceReserved="false"
                     >
@@ -29,6 +30,7 @@
                 <DropDownPreference
                     android:key="select_network_type"
                     android:title="@string/access_networktype"
+                    android:defaultValue=""
                     app:iconSpaceReserved="false" />
                 <EditTextPreference
                     android:key="add_plmn"

--- a/app/src/main/res/xml/preference_mqtt.xml
+++ b/app/src/main/res/xml/preference_mqtt.xml
@@ -14,17 +14,20 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:title="MQTT Service"
+        android:summary="@string/mqtt_summary"
         app:iconSpaceReserved="false">
 
         <SwitchPreferenceCompat
             app:iconSpaceReserved="false"
             app:key="enable_mqtt"
+            android:defaultValue="false"
             app:summary="@string/enable_mqtt"
             app:dependency="mqtt_host"
             app:title="@string/enable_logging" />
         <SwitchPreferenceCompat
             app:iconSpaceReserved="false"
             app:key="enable_mqtt_on_boot"
+            android:defaultValue="false"
             app:summary="@string/enable_mqtt_on_boot"
             app:title="@string/start_logging_on_boot" />
     </PreferenceCategory>
@@ -32,15 +35,16 @@
     <PreferenceCategory
         app:iconSpaceReserved="false"
         app:key="mqtt_credentials"
+        android:summary="@string/mqtt_credentials_summary"
         app:title="MQTT Credentials">
 
         <EditTextPreference
             android:dialogTitle="@string/mqtt_host_dialog_title"
             app:iconSpaceReserved="false"
             app:key="mqtt_host"
-
+            android:defaultValue="@string/mqtt_host_hint"
             app:title="@string/mqtt_host"
-            android:hint="@string/mqtt_host_hint"
+            android:summary="@string/mqtt_host_summary"
             app:useSimpleSummaryProvider="true" />
 
         <EditTextPreference
@@ -48,6 +52,7 @@
             app:iconSpaceReserved="false"
             app:key="mqtt_client_username"
             app:dependency="enable_mqtt"
+            android:defaultValue="USERNAME"
             app:summary="@string/mqtt_client_username_summary"
             app:title="@string/mqtt_client_user_name_title" />
 
@@ -56,7 +61,9 @@
             app:dependency="enable_mqtt"
             app:iconSpaceReserved="false"
             app:key="mqtt_client_password"
+            android:defaultValue="PASSWORD"
             app:title="@string/mqtt_client_password"
+            android:summary="@string/mqtt_client_password_summary"
             app:useSimpleSummaryProvider="true" />
 
     </PreferenceCategory>

--- a/docs/OpenMobileNetworkToolkit.md
+++ b/docs/OpenMobileNetworkToolkit.md
@@ -23,3 +23,4 @@
         * [Set subscription](settings/set_subscrption.md)
         * [Reboot Modem](settings/reboot_modem.md)
     
+* Auto generated [Preferences](./preferences.md)

--- a/docs/config.json
+++ b/docs/config.json
@@ -161,32 +161,7 @@
                         "type": "string"
                     },
                     {
-                        "key": "log_settings",
-                        "value": null,
-                        "type": "string"
-                    },
-                    {
-                        "key": "mobile_network_settings",
-                        "value": null,
-                        "type": "string"
-                    },
-                    {
                         "key": "select_subscription",
-                        "value": null,
-                        "type": "string"
-                    },
-                    {
-                        "key": "reset_modem",
-                        "value": null,
-                        "type": "string"
-                    },
-                    {
-                        "key": "mqtt_settings",
-                        "value": null,
-                        "type": "string"
-                    },
-                    {
-                        "key": "shared_preferences_io",
                         "value": null,
                         "type": "string"
                     }
@@ -241,11 +216,6 @@
                 "name": "radio_settings",
                 "preferences": [
                     {
-                        "key": "doc",
-                        "value": null,
-                        "type": "string"
-                    },
-                    {
                         "key": "select_network_type",
                         "value": null,
                         "type": "string"
@@ -259,16 +229,6 @@
                         "key": "persist_boot",
                         "value": null,
                         "type": "boolean"
-                    }
-                ]
-            },
-            {
-                "name": "carrier_settings",
-                "preferences": [
-                    {
-                        "key": "apply_cs_settings",
-                        "value": null,
-                        "type": "string"
                     }
                 ]
             },
@@ -553,7 +513,7 @@
         "metadata": {
             "version": "0.7",
             "code": 7,
-            "gitHash": "6637f6d"
+            "gitHash": "9d3ed7b"
         }
     }
 ]

--- a/docs/config.json
+++ b/docs/config.json
@@ -1,0 +1,559 @@
+[
+    {
+        "setting": "logging",
+        "categories": [
+            {
+                "name": "logging_service",
+                "preferences": [
+                    {
+                        "key": "enable_logging",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "start_logging_on_boot",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "logging_interval",
+                        "value": null,
+                        "type": "string"
+                    }
+                ]
+            },
+            {
+                "name": "local_logging",
+                "preferences": [
+                    {
+                        "key": "enable_local_influx_log",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "enable_local_file_log",
+                        "value": null,
+                        "type": "boolean"
+                    }
+                ]
+            },
+            {
+                "name": "remote_logging",
+                "preferences": [
+                    {
+                        "key": "enable_influx",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "influx_URL",
+                        "value": null,
+                        "type": "string"
+                    },
+                    {
+                        "key": "influx_org",
+                        "value": null,
+                        "type": "string"
+                    },
+                    {
+                        "key": "influx_token",
+                        "value": null,
+                        "type": "string"
+                    },
+                    {
+                        "key": "influx_bucket",
+                        "value": null,
+                        "type": "string"
+                    }
+                ]
+            },
+            {
+                "name": "logging_content",
+                "preferences": [
+                    {
+                        "key": "fake_location",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "measurement_name",
+                        "value": null,
+                        "type": "string"
+                    },
+                    {
+                        "key": "tags",
+                        "value": null,
+                        "type": "string"
+                    },
+                    {
+                        "key": "influx_network_data",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "log_signal_data",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "influx_cell_data",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "log_neighbour_cells",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "influx_throughput_data",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "log_wifi_data",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "influx_battery_data",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "influx_ip_address_data",
+                        "value": null,
+                        "type": "boolean"
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "setting": "main",
+        "categories": [
+            {
+                "name": "home_screen_settings",
+                "preferences": [
+                    {
+                        "key": "show_neighbour_cells",
+                        "value": null,
+                        "type": "boolean"
+                    }
+                ]
+            },
+            {
+                "name": "notification_settings",
+                "preferences": [
+                    {
+                        "key": "enable_radio_notification",
+                        "value": null,
+                        "type": "boolean"
+                    }
+                ]
+            },
+            {
+                "name": "app_settings",
+                "preferences": [
+                    {
+                        "key": "device_name",
+                        "value": null,
+                        "type": "string"
+                    },
+                    {
+                        "key": "log_settings",
+                        "value": null,
+                        "type": "string"
+                    },
+                    {
+                        "key": "mobile_network_settings",
+                        "value": null,
+                        "type": "string"
+                    },
+                    {
+                        "key": "select_subscription",
+                        "value": null,
+                        "type": "string"
+                    },
+                    {
+                        "key": "reset_modem",
+                        "value": null,
+                        "type": "string"
+                    },
+                    {
+                        "key": "mqtt_settings",
+                        "value": null,
+                        "type": "string"
+                    },
+                    {
+                        "key": "shared_preferences_io",
+                        "value": null,
+                        "type": "string"
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "setting": "mqtt",
+        "categories": [
+            {
+                "name": "mqtt_service",
+                "preferences": [
+                    {
+                        "key": "enable_mqtt",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "enable_mqtt_on_boot",
+                        "value": null,
+                        "type": "boolean"
+                    }
+                ]
+            },
+            {
+                "name": "mqtt_credentials",
+                "preferences": [
+                    {
+                        "key": "mqtt_host",
+                        "value": null,
+                        "type": "string"
+                    },
+                    {
+                        "key": "mqtt_client_username",
+                        "value": null,
+                        "type": "string"
+                    },
+                    {
+                        "key": "mqtt_client_password",
+                        "value": null,
+                        "type": "string"
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "setting": "mobile_network",
+        "categories": [
+            {
+                "name": "radio_settings",
+                "preferences": [
+                    {
+                        "key": "doc",
+                        "value": null,
+                        "type": "string"
+                    },
+                    {
+                        "key": "select_network_type",
+                        "value": null,
+                        "type": "string"
+                    },
+                    {
+                        "key": "add_plmn",
+                        "value": null,
+                        "type": "string"
+                    },
+                    {
+                        "key": "persist_boot",
+                        "value": null,
+                        "type": "boolean"
+                    }
+                ]
+            },
+            {
+                "name": "carrier_settings",
+                "preferences": [
+                    {
+                        "key": "apply_cs_settings",
+                        "value": null,
+                        "type": "string"
+                    }
+                ]
+            },
+            {
+                "name": "android_12_api_31_(s)",
+                "preferences": [
+                    {
+                        "key": "edit_text_EPDG_STATIC_ADDRESS",
+                        "value": null,
+                        "type": "string"
+                    },
+                    {
+                        "key": "multi_select_KEY_CARRIER_NR_AVAILABILITIES_INT_ARRAY",
+                        "value": null,
+                        "type": "set"
+                    },
+                    {
+                        "key": "switch_KEY_HIDE_TTY_HCO_VCO_WITH_RTT_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_HIDE_ENABLE_2G",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_RTT_UPGRADE_SUPPORTED_FOR_DOWNGRADED_VT_CALL_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    }
+                ]
+            },
+            {
+                "name": "android_11_api_30_(r)",
+                "preferences": [
+                    {
+                        "key": "switch_KEY_ALLOW_VIDEO_CALLING_FALLBACK_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_CARRIER_DEFAULT_WFC_IMS_ENABLED_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_HIDE_LTE_PLUS_DATA_ICON_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_WORLD_MODE_ENABLED_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_CARRIER_RCS_PROVISIONING_REQUIRED_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_SHOW_IMS_REGISTRATION_STATUS_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_EDITABLE_WFC_MODE_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_EDITABLE_WFC_ROAMING_MODE_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "edit_text_KEY_READ_ONLY_APN_FIELDS_STRING_ARRAY",
+                        "value": null,
+                        "type": "string"
+                    },
+                    {
+                        "key": "edit_text_KEY_APN_SETTINGS_DEFAULT_APN_TYPES_STRING_ARRAY",
+                        "value": null,
+                        "type": "string"
+                    },
+                    {
+                        "key": "switch_KEY_CARRIER_ALLOW_DEFLECT_IMS_CALL_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    }
+                ]
+            },
+            {
+                "name": "android_10_api_29_(q)",
+                "preferences": [
+                    {
+                        "key": "switch_KEY_FORCE_HOME_NETWORK_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_PREFER_2G_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_CARRIER_SETTINGS_ENABLE_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_CARRIER_ALLOW_TURNOFF_IMS_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_CARRIER_WFC_IMS_AVAILABLE_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_EDITABLE_ENHANCED_4G_LTE_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_CARRIER_VOLTE_AVAILABLE_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_CARRIER_VOLTE_PROVISIONING_REQUIRED_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_CARRIER_VOLTE_PROVISIONED_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_CARRIER_VT_AVAILABLE_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_CARRIER_VOLTE_TTY_SUPPORTED_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_HIDE_ENHANCED_4G_LTE_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_HIDE_CARRIER_NETWORK_SETTINGS_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_HIDE_IMS_APN_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_HIDE_PREFERRED_NETWORK_TYPE_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_HIDE_PRESET_APN_DETAILS_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_HIDE_SIM_LOCK_SETTINGS_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_ALLOW_ADDING_APNS_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_APN_EXPAND_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_CARRIER_WFC_SUPPORTS_WIFI_ONLY_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_CARRIER_IMS_GBA_REQUIRED_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_REQUIRE_ENTITLEMENT_CHECKS_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "list_KEY_VOLTE_REPLACEMENT_RAT_INT9",
+                        "value": null,
+                        "type": "string"
+                    },
+                    {
+                        "key": "switch_KEY_CARRIER_USE_IMS_FIRST_FOR_EMERGENCY_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_AUTO_RETRY_ENABLED_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_WORLD_PHONE_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_SUPPORT_PAUSE_IMS_VIDEO_CALLS_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_CARRIER_UT_PROVISIONING_REQUIRED_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_CARRIER_SUPPORTS_SS_OVER_UT_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_ENHANCED_4G_LTE_ON_BY_DEFAULT_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "switch_KEY_SUPPORT_EMERGENCY_SMS_OVER_IMS_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    },
+                    {
+                        "key": "list_KEY_CARRIER_DEFAULT_WFC_IMS_MODE_INT",
+                        "value": null,
+                        "type": "string"
+                    },
+                    {
+                        "key": "list_KEY_CARRIER_DEFAULT_WFC_IMS_ROAMING_MODE_INT",
+                        "value": null,
+                        "type": "string"
+                    },
+                    {
+                        "key": "switch_KEY_ALLOW_EMERGENCY_VIDEO_CALLS_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    }
+                ]
+            },
+            {
+                "name": "android_8_api_27_(0_mr1)",
+                "preferences": [
+                    {
+                        "key": "switch_KEY_DISPLAY_HD_AUDIO_PROPERTY_BOOL",
+                        "value": null,
+                        "type": "boolean"
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "metadata": {
+            "version": "0.7",
+            "code": 7,
+            "gitHash": "6637f6d"
+        }
+    }
+]

--- a/docs/preferences.md
+++ b/docs/preferences.md
@@ -1,8 +1,8 @@
 # Preferences Documentation
 
-# Logging
+## Logging
 
-## Logging Service
+### Logging Service
 
 _This configures the logging Service of OMNT._
 
@@ -12,7 +12,7 @@ _This configures the logging Service of OMNT._
 | **start_logging_on_boot** | Start on boot | Start the logging service on device boot | `false` |
 | **logging_interval** | Interval | Logging interval in milliseconds | `1000` |
 
-## Local logging
+### Local logging
 
 _This configures a local InfluxDB instance, running on the Device, to log data to. EXPERIMENTAL_
 
@@ -21,7 +21,7 @@ _This configures a local InfluxDB instance, running on the Device, to log data t
 | **enable_local_influx_log** | InfluxDB log | Log to a local Influx 2.x database | `fals` |
 | **enable_local_file_log** | Log file | Log to a local file | `false` |
 
-## Remote logging
+### Remote logging
 
 _This configures a remote InfluxDB instance to log data to._
 
@@ -33,7 +33,7 @@ _This configures a remote InfluxDB instance to log data to._
 | **influx_token** | Influx Token | Influx TOKEN | `TOKEN` |
 | **influx_bucket** | InfluxDB bucket | Influx Bucket Name or ID. | `BUCKET_NAME` |
 
-## Logging content
+### Logging content
 
 | Key | Title | Summary | Default Value |
 | --- | ----- | ------- | ------------- |
@@ -49,21 +49,21 @@ _This configures a remote InfluxDB instance to log data to._
 | **influx_battery_data** | Log battery information | This will log BatteryInformation data to InfluxDB. Like BatteryLevel and Charging Status. | `false` |
 | **influx_ip_address_data** | Log IP addresses | This will log IPAddressInformation data to InfluxDB. Like IPv4 and IPv6 addresses, and the interface name. | `false` |
 
-# Main
+## Main
 
-## Home screen settings
+### Home screen settings
 
 | Key | Title | Summary | Default Value |
 | --- | ----- | ------- | ------------- |
-| **show_neighbour_cells** | Show neighbour cells | Shows Neighbour cells only when connected to a Network and is announced by the network. | `false` |
+| **show_neighbour_cells** | Show neighbour cells | Shows neighbour cells only when connected to a network and is announced by the network. | `false` |
 
-## Notification settings
+### Notification settings
 
 | Key | Title | Summary | Default Value |
 | --- | ----- | ------- | ------------- |
 | **enable_radio_notification** | Enable Cell Notification | Serving Cell Parameter: PCI, RSRP... | `false` |
 
-## App settings
+### App settings
 
 | Key | Title | Summary | Default Value |
 | --- | ----- | ------- | ------------- |
@@ -75,9 +75,9 @@ _This configures a remote InfluxDB instance to log data to._
 | **mqtt_settings** | MQTT Settings | Configure MQTT for OMNT. |  |
 | **shared_preferences_io** | Config | Import/Export Config of OMNT. |  |
 
-# Mqtt
+## Mqtt
 
-## MQTT Service
+### MQTT Service
 
 _Enables MQTT Services for OMNT._
 
@@ -86,7 +86,7 @@ _Enables MQTT Services for OMNT._
 | **enable_mqtt** | Enable | Enable MQTT | `false` |
 | **enable_mqtt_on_boot** | Start on boot | Enable MQTT on boot | `false` |
 
-## MQTT Credentials
+### MQTT Credentials
 
 _Section to set Credentials for MQTT._
 
@@ -96,9 +96,9 @@ _Section to set Credentials for MQTT._
 | **mqtt_client_username** | MQTT Client Username | MQTT Username | `USERNAME` |
 | **mqtt_client_password** | MQTT Client Password | MQTT Client Password. | `PASSWORD` |
 
-# Mobile network
+## Mobile network
 
-## Radio Settings
+### Radio Settings
 
 | Key | Title | Summary | Default Value |
 | --- | ----- | ------- | ------------- |
@@ -107,7 +107,7 @@ _Section to set Credentials for MQTT._
 | **add_plmn** | Set PLMN |  |  |
 | **persist_boot** | Persist until reboot |  |  |
 
-## Carrier Settings
+### Carrier Settings
 
 _Applied on SIM / network change_
 
@@ -115,7 +115,7 @@ _Applied on SIM / network change_
 | --- | ----- | ------- | ------------- |
 | **apply_cs_settings** | Apply carrier settings now |  |  |
 
-## Android 12 API 31 (S)
+### Android 12 API 31 (S)
 
 | Key | Title | Summary | Default Value |
 | --- | ----- | ------- | ------------- |
@@ -125,7 +125,7 @@ _Applied on SIM / network change_
 | **switch_KEY_HIDE_ENABLE_2G** | HIDE_ENABLE_2G |  | `false` |
 | **switch_KEY_RTT_UPGRADE_SUPPORTED_FOR_DOWNGRADED_VT_CALL_BOOL** | RTT_UPGRADE_SUPPORTED_FOR_DOWNGRADED_VT_CALL_BOOL |  | `true` |
 
-## Android 11 API 30 (R)
+### Android 11 API 30 (R)
 
 | Key | Title | Summary | Default Value |
 | --- | ----- | ------- | ------------- |
@@ -141,7 +141,7 @@ _Applied on SIM / network change_
 | **edit_text_KEY_APN_SETTINGS_DEFAULT_APN_TYPES_STRING_ARRAY** | APN_SETTINGS_DEFAULT_APN_TYPES_STRING_ARRAY |  |  |
 | **switch_KEY_CARRIER_ALLOW_DEFLECT_IMS_CALL_BOOL** | CARRIER_ALLOW_DEFLECT_IMS_CALL_BOOL |  | `true` |
 
-## Android 10 API 29 (Q)
+### Android 10 API 29 (Q)
 
 | Key | Title | Summary | Default Value |
 | --- | ----- | ------- | ------------- |
@@ -180,7 +180,7 @@ _Applied on SIM / network change_
 | **list_KEY_CARRIER_DEFAULT_WFC_IMS_ROAMING_MODE_INT** | CARRIER_DEFAULT_WFC_IMS_ROAMING_MODE_INT |  | `1` |
 | **switch_KEY_ALLOW_EMERGENCY_VIDEO_CALLS_BOOL** | ALLOW_EMERGENCY_VIDEO_CALLS_BOOL |  | `false` |
 
-## Android 8 API 27 (0_MR1)
+### Android 8 API 27 (0_MR1)
 
 | Key | Title | Summary | Default Value |
 | --- | ----- | ------- | ------------- |

--- a/docs/preferences.md
+++ b/docs/preferences.md
@@ -1,0 +1,188 @@
+# Preferences Documentation
+
+# Logging
+
+## Logging Service
+
+_This configures the logging Service of OMNT._
+
+| Key | Title | Summary | Default Value |
+| --- | ----- | ------- | ------------- |
+| **enable_logging** | Enable | Start / stop the logging service | `false` |
+| **start_logging_on_boot** | Start on boot | Start the logging service on device boot | `false` |
+| **logging_interval** | Interval | Logging interval in milliseconds | `1000` |
+
+## Local logging
+
+_This configures a local InfluxDB instance, running on the Device, to log data to. EXPERIMENTAL_
+
+| Key | Title | Summary | Default Value |
+| --- | ----- | ------- | ------------- |
+| **enable_local_influx_log** | InfluxDB log | Log to a local Influx 2.x database | `fals` |
+| **enable_local_file_log** | Log file | Log to a local file | `false` |
+
+## Remote logging
+
+_This configures a remote InfluxDB instance to log data to._
+
+| Key | Title | Summary | Default Value |
+| --- | ----- | ------- | ------------- |
+| **enable_influx** | InfluxDB log | Log to a remote Influx 2.x database | `false` |
+| **influx_URL** | InfluxDB instance URL / IP | Influx URL, it can either be http://IP:8086, https://IP:8086, or any hostname. | `http://IP:8086` |
+| **influx_org** | InfluxDB Organization | Influx ORG Name, or ID. | `ORG` |
+| **influx_token** | Influx Token | Influx TOKEN | `TOKEN` |
+| **influx_bucket** | InfluxDB bucket | Influx Bucket Name or ID. | `BUCKET_NAME` |
+
+## Logging content
+
+| Key | Title | Summary | Default Value |
+| --- | ----- | ------- | ------------- |
+| **fake_location** | Use fake location | Use a fake location for all measurements for testing / privacy reasons | `false` |
+| **measurement_name** | Measurement name |  | `omnt` |
+| **tags** | Tags | Comma separated list of tags |  |
+| **influx_network_data** | Log network information | This will log NetworkInformation to InfluxDB. Like NetworkOperatorName, SimOperatorName, DataNetworkType. | `false` |
+| **log_signal_data** | Log signal data | This will log SignalStrength to InfluxDB. Like RSRP, RSRQ from the SignalStrength API. | `false` |
+| **influx_cell_data** | Log cell information | This will log CellInformation to InfluxDB. Like CellId, MCC, MNC, PCI, but also RSRP, RSRQ from the CellInformation API. | `true` |
+| **log_neighbour_cells** | Log neighbour cells | This will log neighbour CellInformation data to InfluxDB. Like CellId, MCC, MNC, PCI, but also RSRP, RSRQ from the CellInformation API. | `false` |
+| **influx_throughput_data** | Log throughput information | This will log InterfaceThroughput data to InfluxDB. Like download and upload throughput, what the phone thinks what is currently possible. | `false` |
+| **log_wifi_data** | Log WiFi information | This will log WifiInformation data to InfluxDB. Like SSID, BSSID, RSSI, Frequency, LinkSpeed, and WifiStandard. | `false` |
+| **influx_battery_data** | Log battery information | This will log BatteryInformation data to InfluxDB. Like BatteryLevel and Charging Status. | `false` |
+| **influx_ip_address_data** | Log IP addresses | This will log IPAddressInformation data to InfluxDB. Like IPv4 and IPv6 addresses, and the interface name. | `false` |
+
+# Main
+
+## Home screen settings
+
+| Key | Title | Summary | Default Value |
+| --- | ----- | ------- | ------------- |
+| **show_neighbour_cells** | Show neighbour cells | Shows Neighbour cells only when connected to a Network and is announced by the network. | `false` |
+
+## Notification settings
+
+| Key | Title | Summary | Default Value |
+| --- | ----- | ------- | ------------- |
+| **enable_radio_notification** | Enable Cell Notification | Serving Cell Parameter: PCI, RSRP... | `false` |
+
+## App settings
+
+| Key | Title | Summary | Default Value |
+| --- | ----- | ------- | ------------- |
+| **device_name** | Unique Device Name | Set unique device name. | `OMNT0001` |
+| **log_settings** | Logging | Configure the Logging Parameter. |  |
+| **mobile_network_settings** | Mobile Network | Configure Mobile Network Settings, only if the App has Carrier Permissions. |  |
+| **select_subscription** | Set subscription (SIM) |  | `1` |
+| **reset_modem** | Reboot Modem | Reboots the modem, only possible when OMNT has Carrier Permissions. |  |
+| **mqtt_settings** | MQTT Settings | Configure MQTT for OMNT. |  |
+| **shared_preferences_io** | Config | Import/Export Config of OMNT. |  |
+
+# Mqtt
+
+## MQTT Service
+
+_Enables MQTT Services for OMNT._
+
+| Key | Title | Summary | Default Value |
+| --- | ----- | ------- | ------------- |
+| **enable_mqtt** | Enable | Enable MQTT | `false` |
+| **enable_mqtt_on_boot** | Start on boot | Enable MQTT on boot | `false` |
+
+## MQTT Credentials
+
+_Section to set Credentials for MQTT._
+
+| Key | Title | Summary | Default Value |
+| --- | ----- | ------- | ------------- |
+| **mqtt_host** | MQTT-Broker Address | MQTT Broker Address | `tcp://192.168.213.89:1883` |
+| **mqtt_client_username** | MQTT Client Username | MQTT Username | `USERNAME` |
+| **mqtt_client_password** | MQTT Client Password | MQTT Client Password. | `PASSWORD` |
+
+# Mobile network
+
+## Radio Settings
+
+| Key | Title | Summary | Default Value |
+| --- | ----- | ------- | ------------- |
+| **doc** | Click here for Android Doc | Opens Link to Android Doc. |  |
+| **select_network_type** | Select Access Network Type |  |  |
+| **add_plmn** | Set PLMN |  |  |
+| **persist_boot** | Persist until reboot |  |  |
+
+## Carrier Settings
+
+_Applied on SIM / network change_
+
+| Key | Title | Summary | Default Value |
+| --- | ----- | ------- | ------------- |
+| **apply_cs_settings** | Apply carrier settings now |  |  |
+
+## Android 12 API 31 (S)
+
+| Key | Title | Summary | Default Value |
+| --- | ----- | ------- | ------------- |
+| **edit_text_EPDG_STATIC_ADDRESS** | EPDG_STATIC_ADDRESS |  |  |
+| **multi_select_KEY_CARRIER_NR_AVAILABILITIES_INT_ARRAY** | CARRIER_NR_AVAILABILITIES_INT_ARRAY |  |  |
+| **switch_KEY_HIDE_TTY_HCO_VCO_WITH_RTT_BOOL** | HIDE_TTY_HCO_VCO_WITH_RTT_BOOL |  | `false` |
+| **switch_KEY_HIDE_ENABLE_2G** | HIDE_ENABLE_2G |  | `false` |
+| **switch_KEY_RTT_UPGRADE_SUPPORTED_FOR_DOWNGRADED_VT_CALL_BOOL** | RTT_UPGRADE_SUPPORTED_FOR_DOWNGRADED_VT_CALL_BOOL |  | `true` |
+
+## Android 11 API 30 (R)
+
+| Key | Title | Summary | Default Value |
+| --- | ----- | ------- | ------------- |
+| **switch_KEY_ALLOW_VIDEO_CALLING_FALLBACK_BOOL** | ALLOW_VIDEO_CALLING_FALLBACK_BOOL |  | `true` |
+| **switch_KEY_CARRIER_DEFAULT_WFC_IMS_ENABLED_BOOL** | CARRIER_DEFAULT_WFC_IMS_ENABLED_BOOL |  | `false` |
+| **switch_KEY_HIDE_LTE_PLUS_DATA_ICON_BOOL** | HIDE_LTE_PLUS_DATA_ICON_BOOL |  | `false` |
+| **switch_KEY_WORLD_MODE_ENABLED_BOOL** | WORLD_MODE_ENABLED_BOOL |  | `true` |
+| **switch_KEY_CARRIER_RCS_PROVISIONING_REQUIRED_BOOL** | CARRIER_RCS_PROVISIONING_REQUIRED_BOOL |  | `false` |
+| **switch_KEY_SHOW_IMS_REGISTRATION_STATUS_BOOL** | SHOW_IMS_REGISTRATION_STATUS_BOOL |  | `true` |
+| **switch_KEY_EDITABLE_WFC_MODE_BOOL** | EDITABLE_WFC_MODE_BOOL |  | `true` |
+| **switch_KEY_EDITABLE_WFC_ROAMING_MODE_BOOL** | EDITABLE_WFC_ROAMING_MODE_BOOL |  | `true` |
+| **edit_text_KEY_READ_ONLY_APN_FIELDS_STRING_ARRAY** | READ_ONLY_APN_FIELDS_STRING_ARRAY |  |  |
+| **edit_text_KEY_APN_SETTINGS_DEFAULT_APN_TYPES_STRING_ARRAY** | APN_SETTINGS_DEFAULT_APN_TYPES_STRING_ARRAY |  |  |
+| **switch_KEY_CARRIER_ALLOW_DEFLECT_IMS_CALL_BOOL** | CARRIER_ALLOW_DEFLECT_IMS_CALL_BOOL |  | `true` |
+
+## Android 10 API 29 (Q)
+
+| Key | Title | Summary | Default Value |
+| --- | ----- | ------- | ------------- |
+| **switch_KEY_FORCE_HOME_NETWORK_BOOL** | FORCE_HOME_NETWORK_BOOL |  | `false` |
+| **switch_KEY_PREFER_2G_BOOL** | PREFER_2G_BOOL |  | `false` |
+| **switch_KEY_CARRIER_SETTINGS_ENABLE_BOOL** | CARRIER_SETTINGS_ENABLE_BOOL |  | `true` |
+| **switch_KEY_CARRIER_ALLOW_TURNOFF_IMS_BOOL** | CARRIER_ALLOW_TURNOFF_IMS_BOOL |  | `true` |
+| **switch_KEY_CARRIER_WFC_IMS_AVAILABLE_BOOL** | CARRIER_WFC_IMS_AVAILABLE_BOOL |  | `true` |
+| **switch_KEY_EDITABLE_ENHANCED_4G_LTE_BOOL** | EDITABLE_ENHANCED_4G_LTE_BOOL |  | `true` |
+| **switch_KEY_CARRIER_VOLTE_AVAILABLE_BOOL** | CARRIER_VOLTE_AVAILABLE_BOOL |  | `true` |
+| **switch_KEY_CARRIER_VOLTE_PROVISIONING_REQUIRED_BOOL** | CARRIER_VOLTE_PROVISIONING_REQUIRED_BOOL |  | `false` |
+| **switch_KEY_CARRIER_VOLTE_PROVISIONED_BOOL** | CARRIER_VOLTE_PROVISIONED_BOOL |  | `false` |
+| **switch_KEY_CARRIER_VT_AVAILABLE_BOOL** | CARRIER_VT_AVAILABLE_BOOL |  | `false` |
+| **switch_KEY_CARRIER_VOLTE_TTY_SUPPORTED_BOOL** | CARRIER_VOLTE_TTY_SUPPORTED_BOOL |  | `false` |
+| **switch_KEY_HIDE_ENHANCED_4G_LTE_BOOL** | HIDE_ENHANCED_4G_LTE_BOOL |  | `false` |
+| **switch_KEY_HIDE_CARRIER_NETWORK_SETTINGS_BOOL** | HIDE_CARRIER_NETWORK_SETTINGS_BOOL |  | `false` |
+| **switch_KEY_HIDE_IMS_APN_BOOL** | HIDE_IMS_APN_BOOL |  | `false` |
+| **switch_KEY_HIDE_PREFERRED_NETWORK_TYPE_BOOL** | HIDE_PREFERRED_NETWORK_TYPE_BOOL |  | `false` |
+| **switch_KEY_HIDE_PRESET_APN_DETAILS_BOOL** | HIDE_PRESET_APN_DETAILS_BOOL |  | `false` |
+| **switch_KEY_HIDE_SIM_LOCK_SETTINGS_BOOL** | HIDE_SIM_LOCK_SETTINGS_BOOL |  | `false` |
+| **switch_KEY_ALLOW_ADDING_APNS_BOOL** | ALLOW_ADDING_APNS_BOOL |  | `true` |
+| **switch_KEY_APN_EXPAND_BOOL** | APN_EXPAND_BOOL |  | `true` |
+| **switch_KEY_CARRIER_WFC_SUPPORTS_WIFI_ONLY_BOOL** | CARRIER_WFC_SUPPORTS_WIFI_ONLY_BOOL |  | `false` |
+| **switch_KEY_CARRIER_IMS_GBA_REQUIRED_BOOL** | CARRIER_IMS_GBA_REQUIRED_BOOL |  | `false` |
+| **switch_KEY_REQUIRE_ENTITLEMENT_CHECKS_BOOL** | REQUIRE_ENTITLEMENT_CHECKS_BOOL |  | `false` |
+| **list_KEY_VOLTE_REPLACEMENT_RAT_INT9** | VOLTE_REPLACEMENT_RAT_INT |  | `18` |
+| **switch_KEY_CARRIER_USE_IMS_FIRST_FOR_EMERGENCY_BOOL** | CARRIER_USE_IMS_FIRST_FOR_EMERGENCY_BOOL |  | `false` |
+| **switch_KEY_AUTO_RETRY_ENABLED_BOOL** | AUTO_RETRY_ENABLED_BOOL |  | `false` |
+| **switch_KEY_WORLD_PHONE_BOOL** | WORLD_PHONE_BOOL |  | `true` |
+| **switch_KEY_SUPPORT_PAUSE_IMS_VIDEO_CALLS_BOOL** | SUPPORT_PAUSE_IMS_VIDEO_CALLS_BOOL |  | `false` |
+| **switch_KEY_CARRIER_UT_PROVISIONING_REQUIRED_BOOL** | CARRIER_UT_PROVISIONING_REQUIRED_BOOL |  | `false` |
+| **switch_KEY_CARRIER_SUPPORTS_SS_OVER_UT_BOOL** | CARRIER_SUPPORTS_SS_OVER_UT_BOOL |  | `false` |
+| **switch_KEY_ENHANCED_4G_LTE_ON_BY_DEFAULT_BOOL** | ENHANCED_4G_LTE_ON_BY_DEFAULT_BOOL |  | `false` |
+| **switch_KEY_SUPPORT_EMERGENCY_SMS_OVER_IMS_BOOL** | SUPPORT_EMERGENCY_SMS_OVER_IMS_BOOL |  | `false` |
+| **list_KEY_CARRIER_DEFAULT_WFC_IMS_MODE_INT** | CARRIER_DEFAULT_WFC_IMS_MODE_INT |  | `1` |
+| **list_KEY_CARRIER_DEFAULT_WFC_IMS_ROAMING_MODE_INT** | CARRIER_DEFAULT_WFC_IMS_ROAMING_MODE_INT |  | `1` |
+| **switch_KEY_ALLOW_EMERGENCY_VIDEO_CALLS_BOOL** | ALLOW_EMERGENCY_VIDEO_CALLS_BOOL |  | `false` |
+
+## Android 8 API 27 (0_MR1)
+
+| Key | Title | Summary | Default Value |
+| --- | ----- | ------- | ------------- |
+| **switch_KEY_DISPLAY_HD_AUDIO_PROPERTY_BOOL** | DISPLAY_HD_AUDIO_PROPERTY_BOOL |  | `false` |
+


### PR DESCRIPTION
## Added
- Markdown documentation detailing all settings parameters, [see](https://github.com/omnt/OpenMobileNetworkToolkit/blob/f00324b05a54eb4d1b30d25b9f9c5a27dba59403/docs/preferences.md?plain=1#L1).
- Automatically generated configuration file based on preference XMLs located in `src/main/res/xml/`.

## Changed
- Removed import/export functionality for iPerf3 and Ping parameters.  
- Renamed `SPType` enum values for improved clarity.

## Fixed
- Resolved display issue when importing configuration files.

## Breaking Changes
- Legacy configuration files are no longer compatible.
